### PR TITLE
Disabled Exit Button for W3C Players to Ensure Proper Match Results

### DIFF
--- a/src/app/ui/console.ts
+++ b/src/app/ui/console.ts
@@ -1,4 +1,4 @@
-import { MAP_VERSION } from '../utils/map-info';
+import { MAP_VERSION, W3C_MODE_ENABLED } from '../utils/map-info';
 import { PLAYER_SLOTS } from '../utils/utils';
 
 /**
@@ -102,6 +102,17 @@ export function SetConsoleUI() {
 	BlzFrameClick(BlzGetFrameByName('QuestAcceptButton', 0));
 	BlzFrameSetSize(BlzGetFrameByName('QuestItemListContainer', 0), 0.01, 0.01);
 	BlzFrameSetSize(BlzGetFrameByName('QuestItemListScrollBar', 0), 0.001, 0.001);
+
+	// Disable exit button for W3C mode
+	if (W3C_MODE_ENABLED) {
+		BlzFrameSetVisible(BlzGetFrameByName('EscMenuSaveLoadContainer', 0), false);
+		BlzFrameSetEnable(BlzGetFrameByName('SaveGameFileEditBox', 0), false);
+		if (!IsPlayerObserver(GetLocalPlayer())) {
+			BlzFrameSetVisible(BlzGetFrameByName('ExitButton', 0), false);
+			BlzFrameSetEnable(BlzGetFrameByName('ConfirmQuitQuitButton', 0), false);
+			BlzFrameSetText(BlzGetFrameByName('ConfirmQuitMessageText', 0), 'Please use Quit Mission instead.');
+		}
+	}
 }
 
 /**

--- a/src/app/ui/console.ts
+++ b/src/app/ui/console.ts
@@ -105,12 +105,19 @@ export function SetConsoleUI() {
 
 	// Disable exit button for W3C mode
 	if (W3C_MODE_ENABLED) {
+		// Get all Frames outside of local scope to prevent async issues
+		const escMenuSaveLoadContainer: framehandle = BlzGetFrameByName('EscMenuSaveLoadContainer', 0);
+		const saveGameFileEditBox: framehandle = BlzGetFrameByName('SaveGameFileEditBox', 0);
+		const exitButton: framehandle = BlzGetFrameByName('ExitButton', 0);
+		const confirmQuitQuitButton: framehandle = BlzGetFrameByName('ConfirmQuitQuitButton', 0);
+		const confirmQuitMessageText: framehandle = BlzGetFrameByName('ConfirmQuitMessageText', 0);
+
 		if (!IsPlayerObserver(GetLocalPlayer())) {
-			BlzFrameSetVisible(BlzGetFrameByName('EscMenuSaveLoadContainer', 0), false);
-			BlzFrameSetEnable(BlzGetFrameByName('SaveGameFileEditBox', 0), false);
-			BlzFrameSetVisible(BlzGetFrameByName('ExitButton', 0), false);
-			BlzFrameSetEnable(BlzGetFrameByName('ConfirmQuitQuitButton', 0), false);
-			BlzFrameSetText(BlzGetFrameByName('ConfirmQuitMessageText', 0), 'Please use Quit Mission instead.');
+			BlzFrameSetVisible(escMenuSaveLoadContainer, false);
+			BlzFrameSetEnable(saveGameFileEditBox, false);
+			BlzFrameSetVisible(exitButton, false);
+			BlzFrameSetEnable(confirmQuitQuitButton, false);
+			BlzFrameSetText(confirmQuitMessageText, 'Please use Quit Mission instead.');
 		}
 	}
 }

--- a/src/app/ui/console.ts
+++ b/src/app/ui/console.ts
@@ -105,9 +105,9 @@ export function SetConsoleUI() {
 
 	// Disable exit button for W3C mode
 	if (W3C_MODE_ENABLED) {
-		BlzFrameSetVisible(BlzGetFrameByName('EscMenuSaveLoadContainer', 0), false);
-		BlzFrameSetEnable(BlzGetFrameByName('SaveGameFileEditBox', 0), false);
 		if (!IsPlayerObserver(GetLocalPlayer())) {
+			BlzFrameSetVisible(BlzGetFrameByName('EscMenuSaveLoadContainer', 0), false);
+			BlzFrameSetEnable(BlzGetFrameByName('SaveGameFileEditBox', 0), false);
 			BlzFrameSetVisible(BlzGetFrameByName('ExitButton', 0), false);
 			BlzFrameSetEnable(BlzGetFrameByName('ConfirmQuitQuitButton', 0), false);
 			BlzFrameSetText(BlzGetFrameByName('ConfirmQuitMessageText', 0), 'Please use Quit Mission instead.');


### PR DESCRIPTION
Intent of this feature is to prevent users from not reporting the game result. Only applies to W3C version of the map and players. Observers still have the Exit Button enabled.