### PR TITLE
101 | Add game settings to post-game scorescreen, fix uneven spacing …

### DIFF
--- a/src/app/settings/strategies/fog-strategy.ts
+++ b/src/app/settings/strategies/fog-strategy.ts
@@ -3,16 +3,22 @@ import { SettingsStrategy } from './settings-strategy';
 import { HexColors } from 'src/app/utils/hex-colors';
 import { FogManager } from 'src/app/managers/fog-manager';
 
-export const FogOptions: Record<number, string> = {
+export const FogStrings: Record<number, string> = {
 	0: `Off`,
 	1: `On`,
 	2: `Night`,
 };
 
+export const FogColors: Record<number, string> = {
+	0: `${HexColors.GREEN}`,
+	1: `${HexColors.RED}`,
+	2: `${HexColors.RED}`,
+}
+
 export const FogOptionsColorFormatted: Record<number, string> = {
-	0: `${HexColors.GREEN}${FogOptions[0]}|r`,
-	1: `${HexColors.RED}${FogOptions[1]}|r`,
-	2: `${HexColors.RED}${FogOptions[2]}|r`,
+	0: `${FogColors[0]}${FogStrings[0]}|r`,
+	1: `${FogColors[1]}${FogStrings[1]}|r`,
+	2: `${FogColors[2]}${FogStrings[2]}|r`,
 };
 
 export class FogStrategy implements SettingsStrategy {

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -15,11 +15,18 @@ export const OvertimeStrings: Record<number, string> = {
 	3: `Off`,
 };
 
+export const OvertimeColors: Record<number, string> = {
+	0: `${HexColors.GREEN}`,
+	1: `${HexColors.RED}`,
+	2: `${HexColors.RED}`,
+	3: `${HexColors.RED}`,
+};
+
 export const OvertimeStringsColorFormatted: Record<number, string> = {
-	0: `${HexColors.GREEN}${OvertimeStrings[0]}|r`,
-	1: `${HexColors.RED}${OvertimeStrings[1]}|r`,
-	2: `${HexColors.RED}${OvertimeStrings[2]}|r`,
-	3: `${HexColors.RED}${OvertimeStrings[3]}|r`,
+	0: `${OvertimeColors[0]}${OvertimeStrings[0]}|r`,
+	1: `${OvertimeColors[1]}${OvertimeStrings[1]}|r`,
+	2: `${OvertimeColors[2]}${OvertimeStrings[2]}|r`,
+	3: `${OvertimeColors[3]}${OvertimeStrings[3]}|r`,
 };
 
 export class OvertimeStrategy implements SettingsStrategy {

--- a/src/app/statistics/statistics-model.ts
+++ b/src/app/statistics/statistics-model.ts
@@ -9,6 +9,10 @@ import { SettingsContext } from '../settings/settings-context';
 import { TeamManager } from '../teams/team-manager';
 import { Team } from '../teams/team';
 import { ParticipantEntityManager } from '../utils/participant-entity';
+import { DiplomacyStringsColorFormatted } from '../settings/strategies/diplomacy-strategy';
+import { FogColors, FogOptionsColorFormatted } from '../settings/strategies/fog-strategy';
+import { GameTypeOptionsColorFormatted } from '../settings/strategies/game-type-strategy';
+import { OvertimeColors, OvertimeStringsColorFormatted } from '../settings/strategies/overtime-strategy';
 
 export class StatisticsModel {
 	private timePlayed: string;
@@ -80,6 +84,7 @@ export class StatisticsModel {
 	}
 
 	private setGameTime() {
+		const settingsManager = SettingsContext.getInstance();
 		const turnTime: number = TURN_DURATION_IN_SECONDS;
 		const minutes: number = parseInt(BlzFrameGetText(BlzGetFrameByName('ResourceBarSupplyText', 0)));
 		const seconds: number = turnTime - parseInt(BlzFrameGetText(BlzGetFrameByName('ResourceBarUpkeepText', 0)));
@@ -88,7 +93,25 @@ export class StatisticsModel {
 		const formattedTime: string = `${AddLeadingZero(hours)}:${AddLeadingZero(remainingMinutes)}:${AddLeadingZero(seconds)}`;
 		const totalTurns: number = minutes + seconds / turnTime;
 
-		this.timePlayed = `${HexColors.TANGERINE}Game Time:|r ${formattedTime}\n${HexColors.TANGERINE}Total Turns:|r ${totalTurns.toFixed(2)}\n${HexColors.TANGERINE}Version:|r v${MAP_VERSION}`;
+		let settings = '';
+		settings += GameTypeOptionsColorFormatted[settingsManager.getSettings().GameType] + ', ';
+		settings += DiplomacyStringsColorFormatted[settingsManager.getSettings().Diplomacy.option] + ', ';
+		// We want to keep it as short as possible so instead of possibly writing "Overtime: Turbo (Turn 30)" because we
+		// use OvertimeStrings exclusively, we check for value 3 which means overtime is disabled. "Off" wouldn't be
+		// explanatory enough so we check for it and use "No Overtime" instead
+		settings +=
+			OvertimeColors[settingsManager.getSettings().Overtime.option] +
+			(settingsManager.getSettings().Overtime.option === 3
+				? 'No Overtime'
+				: OvertimeStringsColorFormatted[settingsManager.getSettings().Overtime.option]) +
+			'|r, ';
+		settings +=
+			FogColors[settingsManager.getSettings().Fog] + 'Fog|r ' + FogOptionsColorFormatted[settingsManager.getSettings().Fog];
+
+		this.timePlayed = `${HexColors.TANGERINE}Game Time:|r ${formattedTime}
+		${HexColors.TANGERINE}Total Turns:|r ${totalTurns.toFixed(2)}
+		${HexColors.TANGERINE}Version:|r v${MAP_VERSION}
+		${HexColors.TANGERINE}Settings:|r ${settings}`;
 	}
 
 	private sortPlayersByRank(players: ActivePlayer[], winner?: ActivePlayer): ActivePlayer[] {

--- a/src/app/statistics/statistics-view.ts
+++ b/src/app/statistics/statistics-view.ts
@@ -95,8 +95,8 @@ export class StatisticsView {
 
 	public showStats(player: player): void {
 		if (GetLocalPlayer() == player) {
-			BlzFrameSetAbsPoint(this.backdrop, FRAMEPOINT_CENTER, 0.4, 0.26);
 			BlzFrameSetSize(this.backdrop, 1, 0.64);
+			BlzFrameSetAbsPoint(this.backdrop, FRAMEPOINT_CENTER, 0.4, 0.26);
 			BlzFrameSetText(this.minimizeButton, 'Hide Stats');
 
 			this.updateColumnVisibility();
@@ -106,8 +106,8 @@ export class StatisticsView {
 
 	public hideStats(player: player): void {
 		if (GetLocalPlayer() == player) {
-			BlzFrameSetSize(this.backdrop, 1, 0.05);
-			BlzFrameSetAbsPoint(this.backdrop, FRAMEPOINT_CENTER, 0.4, 0.555);
+			BlzFrameSetSize(this.backdrop, 1, 0.08);
+			BlzFrameSetAbsPoint(this.backdrop, FRAMEPOINT_CENTER, 0.4, 0.26 + (0.64 - 0.08) / 2);
 			BlzFrameSetText(this.minimizeButton, 'Show Stats');
 			this.columns.forEach((col) => {
 				BlzFrameSetVisible(col, false);
@@ -143,7 +143,7 @@ export class StatisticsView {
 			BlzFrameSetVisible(column, visible);
 
 			if (!this.page.isPinnedColumn(index) && visible) {
-				BlzFrameSetPoint(column, FRAMEPOINT_TOPLEFT, this.backdrop, FRAMEPOINT_TOPLEFT, headerX, -0.05);
+				BlzFrameSetPoint(column, FRAMEPOINT_TOPLEFT, this.backdrop, FRAMEPOINT_TOPLEFT, headerX, -0.06);
 				headerX += BlzFrameGetWidth(column);
 			}
 		});
@@ -193,9 +193,9 @@ export class StatisticsView {
 	}
 
 	private buildColumns() {
-		const headerY: number = -0.05;
+		const headerY: number = -0.06;
 		const rowHeight: number = StatisticsView.ROW_HEIGHT;
-		let headerX: number = 0.008;
+		let headerX: number = 0.01;
 
 		this.model.getColumnData().forEach((entry, columnIndex) => {
 			const { size, header } = entry;

--- a/src/app/utils/export-statistics/export-game-settings.ts
+++ b/src/app/utils/export-statistics/export-game-settings.ts
@@ -1,7 +1,7 @@
 import { File } from 'w3ts';
 import { SettingsContext } from 'src/app/settings/settings-context';
 import { DiplomacyStrings } from 'src/app/settings/strategies/diplomacy-strategy';
-import { FogOptions } from 'src/app/settings/strategies/fog-strategy';
+import { FogStrings } from 'src/app/settings/strategies/fog-strategy';
 import { GameTypeOptions } from 'src/app/settings/strategies/game-type-strategy';
 import { OvertimeStrings } from 'src/app/settings/strategies/overtime-strategy';
 import { PromodeOptions } from 'src/app/settings/strategies/promode-strategy';
@@ -22,7 +22,7 @@ export class ExportGameSettings {
 		let headers = ['Diplomacy', 'Fog', 'Game Type', 'Overtime', 'Promode'];
 		let rows = [
 			DiplomacyStrings[settings.getSettings().Diplomacy.option],
-			FogOptions[settings.getSettings().Fog],
+			FogStrings[settings.getSettings().Fog],
 			GameTypeOptions[settings.getSettings().GameType],
 			OvertimeStrings[settings.getSettings().Overtime.option],
 			PromodeOptions[settings.getSettings().Promode],


### PR DESCRIPTION
- Fix uneven spacing in BlzFrame
- Add game settings to post-game scorescreen
- Add OvertimeColors, FogColors to access colors individually

Expanded:
<img width="1853" height="1031" alt="image" src="https://github.com/user-attachments/assets/05ed3bab-1377-417e-9339-7bb448bbd617" />

Collapsed:
<img width="1822" height="699" alt="image" src="https://github.com/user-attachments/assets/73415ed1-1120-4157-9741-94a5f809a4a7" />
