### PR TITLE
90 player killer tracker

### DIFF
--- a/src/app/game/event-coordinator.ts
+++ b/src/app/game/event-coordinator.ts
@@ -83,7 +83,7 @@ export class EventCoordinator {
 
 		EventEmitter.getInstance().on(EVENT_SET_GAME_MODE, (gameType: GameType) => this.applyGameMode(gameType));
 
-		EventEmitter.getInstance().on(EVENT_QUEST_UPDATE_PLAYER_STATUS, () => Quests.getInstance().UpdateShuffledPlayerListQuest());
+		EventEmitter.getInstance().on(EVENT_QUEST_UPDATE_PLAYER_STATUS, () => Quests.getInstance().updatePlayersQuest());
 
 		EventEmitter.getInstance().on(EVENT_NEXT_STATE, (data: StateData) => this._currentMode?.nextState(data));
 	}

--- a/src/app/game/game-mode/base-game-mode/countdown-state.ts
+++ b/src/app/game/game-mode/base-game-mode/countdown-state.ts
@@ -2,11 +2,12 @@ import { CountdownMessage } from 'src/app/utils/messages';
 import { PlayGlobalSound } from 'src/app/utils/utils';
 import { BaseState } from '../state/base-state';
 import { StateData } from '../state/state-data';
+import { STARTING_COUNTDOWN } from '../../../../configs/game-settings';
 
 export class CountdownState<T extends StateData> extends BaseState<T> {
 	private initialDuration: number;
 
-	public constructor(duration: number = 10) {
+	public constructor(duration: number = STARTING_COUNTDOWN) {
 		super();
 		this.initialDuration = duration;
 	}

--- a/src/app/game/game-mode/base-game-mode/game-loop-state.ts
+++ b/src/app/game/game-mode/base-game-mode/game-loop-state.ts
@@ -6,7 +6,6 @@ import { GlobalGameData } from '../../state/global-game-state';
 import { updateTickUI } from '../utillity/update-ui';
 import { BaseState } from '../state/base-state';
 import { ScoreboardManager } from 'src/app/scoreboard/scoreboard-manager';
-import { NameManager } from 'src/app/managers/names/name-manager';
 import { ActivePlayer } from 'src/app/player/types/active-player';
 import { HexColors } from 'src/app/utils/hex-colors';
 import { GlobalMessage } from 'src/app/utils/messages';
@@ -243,14 +242,15 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 	}
 
 	onUnitKilled(killingUnit: unit, dyingUnit: unit): void {
-		const player = GetOwningPlayer(killingUnit);
-		const colorString = PLAYER_COLOR_CODES_MAP.get(GetPlayerColor(player));
+		const killingUnitOwner = GetOwningPlayer(killingUnit);
+		const colorString = PLAYER_COLOR_CODES_MAP.get(GetPlayerColor(killingUnitOwner));
 
 		if (GetOwningPlayer(killingUnit) == GetOwningPlayer(dyingUnit) && !IsUnitType(killingUnit, UNIT_TYPE_STRUCTURE)) {
 			if (!IsFoggedToPlayer(GetUnitX(dyingUnit), GetUnitY(dyingUnit), GetLocalPlayer())) {
 				AnnounceOnLocation(`${colorString}Denied`, GetUnitX(dyingUnit), GetUnitY(dyingUnit) + 20, 2.0, 3.0);
 			}
 		}
+
 		ScoreboardManager.getInstance().updatePartial();
 	}
 

--- a/src/app/game/game-mode/base-game-mode/game-over-state.ts
+++ b/src/app/game/game-mode/base-game-mode/game-over-state.ts
@@ -15,7 +15,7 @@ export class GameOverState<T extends StateData> extends BaseState<T> {
 	onEnterState() {
 		GlobalGameData.matchState = 'postMatch';
 
-		Quests.getInstance().UpdateShuffledPlayerListQuest();
+		Quests.getInstance().updatePlayersQuest();
 
 		// Set end data for all remaining active players - defeated players have had their end data set already as they were defeated
 		PlayerManager.getInstance().playersAliveOrNomad.forEach((player) => {

--- a/src/app/game/game-mode/base-game-mode/setup-state.ts
+++ b/src/app/game/game-mode/base-game-mode/setup-state.ts
@@ -90,7 +90,7 @@ export class SetupState<T extends StateData> extends BaseState<T> {
 		EnableDragSelect(false, false);
 
 		StatisticsController.getInstance().useCurrentActivePlayers();
-		Quests.getInstance().UpdateShuffledPlayerListQuest();
+		Quests.getInstance().updatePlayersQuest();
 
 		// To reset and reduce tree hp on first turn
 		if (GlobalGameData.turnCount === 0) {

--- a/src/app/game/game-mode/promode-game-mode/promode-countdown-state.ts
+++ b/src/app/game/game-mode/promode-game-mode/promode-countdown-state.ts
@@ -3,9 +3,11 @@ import { CountdownState } from '../base-game-mode/countdown-state';
 import { CountdownMessage } from 'src/app/utils/messages';
 import { ParticipantEntityManager } from 'src/app/utils/participant-entity';
 import { VictoryManager } from 'src/app/managers/victory-manager';
+import { STARTING_COUNTDOWN } from '../../../../configs/game-settings';
+
 export class PromodeCountdownState extends CountdownState<StateData> {
 	public constructor() {
-		super(10);
+		super(STARTING_COUNTDOWN);
 	}
 
 	override countdownDisplay(duration: number): void {

--- a/src/app/game/game-mode/state/base-state.ts
+++ b/src/app/game/game-mode/state/base-state.ts
@@ -7,10 +7,10 @@ import { GlobalGameData } from '../../state/global-game-state';
 import {
 	onPlayerAliveHandle,
 	onPlayerDeadHandle,
-	onPlayerNomadHandle,
-	onPlayerLeftHandle,
-	onPlayerSTFUHandle,
 	onPlayerForfeitHandle,
+	onPlayerLeftHandle,
+	onPlayerNomadHandle,
+	onPlayerSTFUHandle,
 } from '../utillity/on-player-status';
 
 export abstract class BaseState<T extends StateData> {
@@ -23,6 +23,7 @@ export abstract class BaseState<T extends StateData> {
 	}
 
 	onEnterState() {}
+
 	onExitState() {}
 
 	onPlayerRestart(player: ActivePlayer) {}
@@ -30,26 +31,32 @@ export abstract class BaseState<T extends StateData> {
 	onPlayerAlive(player: ActivePlayer): void {
 		onPlayerAliveHandle(player);
 	}
+
 	onPlayerDead(player: ActivePlayer): void {
 		onPlayerDeadHandle(player);
 		EventEmitter.getInstance().emit(EVENT_QUEST_UPDATE_PLAYER_STATUS);
 	}
+
 	onPlayerNomad(player: ActivePlayer): void {
 		onPlayerNomadHandle(player);
 	}
+
 	onPlayerLeft(player: ActivePlayer): void {
 		onPlayerLeftHandle(player);
 		EventEmitter.getInstance().emit(EVENT_QUEST_UPDATE_PLAYER_STATUS);
 	}
+
 	onPlayerSTFU(player: ActivePlayer): void {
 		onPlayerSTFUHandle(player);
 	}
+
 	onPlayerForfeit(player: ActivePlayer): void {
 		onPlayerForfeitHandle(player);
 		EventEmitter.getInstance().emit(EVENT_QUEST_UPDATE_PLAYER_STATUS);
 	}
 
 	onCityCapture(city: City, preOwner: ActivePlayer, owner: ActivePlayer) {}
+
 	onUnitKilled(killingUnit: unit, dyingUnit: unit) {}
 
 	onCitySelected(city: City, player: player) {}

--- a/src/app/game/game-mode/utillity/on-player-status.ts
+++ b/src/app/game/game-mode/utillity/on-player-status.ts
@@ -38,7 +38,7 @@ export function onPlayerDeadHandle(player: ActivePlayer): void {
 		);
 	}
 
-	Quests.getInstance().UpdateShuffledPlayerListQuest();
+	Quests.getInstance().updatePlayersQuest();
 	ScoreboardManager.getInstance().updatePartial();
 }
 

--- a/src/app/game/game-mode/utillity/on-player-status.ts
+++ b/src/app/game/game-mode/utillity/on-player-status.ts
@@ -1,15 +1,13 @@
-import { GlobalGameData } from 'src/app/game/state/global-game-state';
 import { TimedEvent } from 'src/app/libs/timer/timed-event';
 import { TimedEventManager } from 'src/app/libs/timer/timed-event-manager';
 import { NameManager } from 'src/app/managers/names/name-manager';
-import { VictoryManager } from 'src/app/managers/victory-manager';
 import { PlayerManager } from 'src/app/player/player-manager';
 import { PLAYER_STATUS } from 'src/app/player/status/status-enum';
 import { ActivePlayer } from 'src/app/player/types/active-player';
 import { ScoreboardManager } from 'src/app/scoreboard/scoreboard-manager';
 import { GlobalMessage } from 'src/app/utils/messages';
 import { NOMAD_DURATION, STARTING_INCOME, STFU_DURATION } from 'src/configs/game-settings';
-import { debugPrint } from '../../../utils/debug-print';
+import { Quests } from '../../../quests/quests';
 
 export function onPlayerAliveHandle(player: ActivePlayer): void {
 	player.status.status = PLAYER_STATUS.ALIVE;
@@ -23,10 +21,24 @@ export function onPlayerAliveHandle(player: ActivePlayer): void {
 
 export function onPlayerDeadHandle(player: ActivePlayer): void {
 	player.status.status = PLAYER_STATUS.DEAD;
+
+	player.killedBy = player.trackedData.lastUnitKilledBy;
 	player.setEndData();
 	player.trackedData.income.income = 1;
 
-	GlobalMessage(`${NameManager.getInstance().getDisplayName(player.getPlayer())} has been defeated!`, 'Sound\\Interface\\SecretFound.flac');
+	if (player.killedBy) {
+		GlobalMessage(
+			`${NameManager.getInstance().getDisplayName(player.getPlayer())} has been defeated by ${NameManager.getInstance().getDisplayName(player.killedBy)}!`,
+			'Sound\\Interface\\SecretFound.flac'
+		);
+	} else {
+		GlobalMessage(
+			`${NameManager.getInstance().getDisplayName(player.getPlayer())} has been defeated!`,
+			'Sound\\Interface\\SecretFound.flac'
+		);
+	}
+
+	Quests.getInstance().UpdateShuffledPlayerListQuest();
 	ScoreboardManager.getInstance().updatePartial();
 }
 

--- a/src/app/game/game-mode/w3c-mode/w3c-game-over-state.ts
+++ b/src/app/game/game-mode/w3c-mode/w3c-game-over-state.ts
@@ -21,7 +21,7 @@ export class W3CGameOverState<T extends StateData> extends BaseState<T> {
 	async runAsync(): Promise<void> {
 		GlobalGameData.matchState = 'postMatch';
 
-		Quests.getInstance().UpdateShuffledPlayerListQuest();
+		Quests.getInstance().updatePlayersQuest();
 
 		// Set end data for all remaining active players - defeated players have had their end data set already as they were defeated
 		PlayerManager.getInstance().playersAliveOrNomad.forEach((player) => {

--- a/src/app/player/data/tracked-data.ts
+++ b/src/app/player/data/tracked-data.ts
@@ -16,8 +16,9 @@ export class TrackedData {
 	private _cities: Cities;
 	private _countries: Map<Country, number>;
 	private _killsDeaths: Map<string | player, KillsDeaths>;
-	private _denies: number; 
+	private _denies: number;
 
+	private _lastUnitKilledBy: player;
 	private _units: Set<unit>;
 	private _turnDied: number;
 	private _trainedUnits: Map<number, number>;
@@ -47,6 +48,7 @@ export class TrackedData {
 		this._units = new Set<unit>();
 		this._trainedUnits = new Map<number, number>();
 		this._turnDied = -1;
+		this._lastUnitKilledBy = null;
 	}
 
 	public reset() {
@@ -68,6 +70,7 @@ export class TrackedData {
 		this.units.clear();
 		this._trainedUnits.clear();
 		this.turnDied = 0;
+		this._lastUnitKilledBy = null;
 	}
 
 	public setKDMaps() {
@@ -139,7 +142,7 @@ export class TrackedData {
 		return this._units;
 	}
 
-	public get denies(): number{
+	public get denies(): number {
 		return this._denies;
 	}
 
@@ -157,5 +160,13 @@ export class TrackedData {
 
 	public get trainedUnits(): Map<number, number> {
 		return this._trainedUnits;
+	}
+
+	public get lastUnitKilledBy(): player {
+		return this._lastUnitKilledBy;
+	}
+
+	public set lastUnitKilledBy(value: player) {
+		this._lastUnitKilledBy = value;
 	}
 }

--- a/src/app/player/types/active-player.ts
+++ b/src/app/player/types/active-player.ts
@@ -6,6 +6,7 @@ import { GamePlayer } from './game-player';
 import { NameManager } from 'src/app/managers/names/name-manager';
 import { PLAYER_STATUS } from '../status/status-enum';
 import { GlobalGameData } from 'src/app/game/state/global-game-state';
+import { debugPrint } from '../../utils/debug-print';
 
 //Use lowercase for simplicity here
 const adminList: string[] = ['forlolz#11696', 'poomonky#1939', 'theredbeard#11245', 'easterbunny#2707'];
@@ -16,6 +17,7 @@ export abstract class ActivePlayer implements GamePlayer, Resetable {
 	private _status: Status;
 	private _options: Options;
 	private _admin: boolean;
+	private _killedBy: player;
 
 	constructor(player: player) {
 		this._player = player;
@@ -27,6 +29,7 @@ export abstract class ActivePlayer implements GamePlayer, Resetable {
 			ping: false,
 			board: 0,
 		};
+		this._killedBy = null;
 		this._admin = false;
 
 		adminList.forEach((name) => {
@@ -36,7 +39,7 @@ export abstract class ActivePlayer implements GamePlayer, Resetable {
 		});
 	}
 
-	abstract onKill(victom: player, unit: unit): void;
+	abstract onKill(victim: player, unit: unit): void;
 	abstract onDeath(killer: player, unit: unit): void;
 
 	public getPlayer(): player {
@@ -45,6 +48,9 @@ export abstract class ActivePlayer implements GamePlayer, Resetable {
 
 	public reset(): void {
 		this.trackedData.reset();
+
+		this._killedBy = null;
+
 		this.status.set(PLAYER_STATUS.ALIVE);
 
 		this._options = {
@@ -98,6 +104,14 @@ export abstract class ActivePlayer implements GamePlayer, Resetable {
 
 	public get options(): Options {
 		return this._options;
+	}
+
+	public set killedBy(value: player) {
+		this._killedBy = value;
+	}
+
+	public get killedBy(): player {
+		return this._killedBy;
 	}
 
 	public isAdmin(): boolean {

--- a/src/app/player/types/game-player.ts
+++ b/src/app/player/types/game-player.ts
@@ -1,5 +1,5 @@
 export interface GamePlayer {
-	onKill(victom: player, unit: unit): void;
+	onKill(victim: player, unit: unit): void;
 	onDeath(killer: player, unit: unit): void;
 	getPlayer(): player;
 }

--- a/src/app/player/types/human-player.ts
+++ b/src/app/player/types/human-player.ts
@@ -1,5 +1,6 @@
 import { AnnounceOnUnitObserverOnlyTintedByPlayer } from 'src/app/game/announcer/announce';
 import { ActivePlayer } from './active-player';
+import { debugPrint } from '../../utils/debug-print';
 
 export class HumanPlayer extends ActivePlayer {
 	constructor(player: player) {
@@ -39,22 +40,23 @@ export class HumanPlayer extends ActivePlayer {
 
 	onDeath(killer: player, unit: unit): void {
 		this.trackedData.units.delete(unit);
+		this.trackedData.lastUnitKilledBy = killer;
 
 		if (!this.status.isAlive() && !this.status.isNomad()) return;
 
-		const victom: player = this.getPlayer();
-		if (victom == killer) return;
-		if (IsPlayerAlly(victom, killer)) return;
+		const victim: player = this.getPlayer();
+		if (victim == killer) return;
+		if (IsPlayerAlly(victim, killer)) return;
 
 		const val: number = GetUnitPointValue(unit);
 		const kdData = this.trackedData.killsDeaths;
 
 		kdData.get(killer).deathValue += val;
-		kdData.get(victom).deathValue += val;
+		kdData.get(victim).deathValue += val;
 		kdData.get(`${GetUnitTypeId(unit)}`).deathValue += val;
 
 		kdData.get(killer).deaths++;
-		kdData.get(victom).deaths++;
+		kdData.get(victim).deaths++;
 		kdData.get(`${GetUnitTypeId(unit)}`).deaths++;
 	}
 }

--- a/src/app/player/types/human-player.ts
+++ b/src/app/player/types/human-player.ts
@@ -1,6 +1,5 @@
 import { AnnounceOnUnitObserverOnlyTintedByPlayer } from 'src/app/game/announcer/announce';
 import { ActivePlayer } from './active-player';
-import { debugPrint } from '../../utils/debug-print';
 
 export class HumanPlayer extends ActivePlayer {
 	constructor(player: player) {

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -23,7 +23,7 @@ type QuestType =
 	| 'QUEST_OVERTIME'
 	| 'QUEST_CAMERA'
 	| 'QUEST_SETTINGS'
-	| 'QUEST_SHUFFLED_PLAYER_LIST';
+	| 'QUEST_PLAYERS';
 
 export class Quests {
 	private static instance: Quests = null;
@@ -50,7 +50,7 @@ export class Quests {
 	private Credits() {
 		let description = `Join our community on Discord: https://discord.gg/wc3risk
 		 
-		Devs/Code: ForLolz#11696, microhive#2772, roflmaooo#2930
+		Devs/Code: ForLolz#11696, microhive#2772, roflmaooo#2930, xate#21335
 		Terrain: Nerla#1510
 		Units: Saran, ForLolz#11696
 		Icons: High/Low Health Guard: Moy | High Value Guard: The Panda | Low Value Guard NemoVonFish
@@ -166,7 +166,7 @@ export class Quests {
 		this.BuildQuest('QUEST_SETTINGS', 'Settings', description, 'ReplaceableTextures\\CommandButtons\\BTNEngineeringUpgrade.blp', false);
 	}
 
-	public AddShuffledPlayerListQuest(): void {
+	public addPlayersQuest(): void {
 		let description: string = `${HexColors.YELLOW}Initial Players|r`;
 		let nameList: ActivePlayer[] = [];
 		const playerManager = PlayerManager.getInstance();
@@ -182,11 +182,11 @@ export class Quests {
 		nameList.forEach((player) => {
 			description += `\n${nameManager.getBtag(player.getPlayer())}`;
 		});
-		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
+		this.BuildQuest('QUEST_PLAYERS', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
 	}
 
-	public UpdateShuffledPlayerListQuest(): void {
-		if (!this.quests.has('QUEST_SHUFFLED_PLAYER_LIST')) this.AddShuffledPlayerListQuest();
+	public updatePlayersQuest(): void {
+		if (!this.quests.has('QUEST_PLAYERS')) this.addPlayersQuest();
 
 		let description: string = `${HexColors.YELLOW}Active Players|r`;
 
@@ -214,6 +214,6 @@ export class Quests {
 			}
 		});
 
-		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
+		this.BuildQuest('QUEST_PLAYERS', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
 	}
 }

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -181,13 +181,7 @@ export class Quests {
 		nameList.forEach((player) => {
 			description += `\n${nameManager.getBtag(player.getPlayer())}`;
 		});
-		this.BuildQuest(
-			'QUEST_SHUFFLED_PLAYER_LIST',
-			'Players',
-			description,
-			'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp',
-			false
-		);
+		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
 	}
 
 	public UpdateShuffledPlayerListQuest(): void {
@@ -206,12 +200,6 @@ export class Quests {
 			description += `\n${ParticipantEntityManager.getParticipantColoredBTagPrefixedWithOptionalTeamNumber(player.getPlayer())} (${player.status ? player.status.status : 'Unknown'})`;
 		});
 
-		this.BuildQuest(
-			'QUEST_SHUFFLED_PLAYER_LIST',
-			'Players',
-			description,
-			'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp',
-			false
-		);
+		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
 	}
 }

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -10,6 +10,7 @@ import { PromodeOptionsColorFormatted } from '../settings/strategies/promode-str
 import { HexColors } from '../utils/hex-colors';
 import { ParticipantEntityManager } from '../utils/participant-entity';
 import { ShuffleArray } from '../utils/utils';
+import { debugPrint } from '../utils/debug-print';
 
 /**
  * Responsible for creating in-game quests.
@@ -198,6 +199,19 @@ export class Quests {
 		const eliminatedPlayers = this.shuffledPlayerList.filter((player) => (player.status ? player.status.isEliminated() : false));
 		eliminatedPlayers.forEach((player) => {
 			description += `\n${ParticipantEntityManager.getParticipantColoredBTagPrefixedWithOptionalTeamNumber(player.getPlayer())} (${player.status ? player.status.status : 'Unknown'})`;
+
+			if (player.killedBy) {
+				const killedByActivePlayer = PlayerManager.getInstance().players.get(player.killedBy);
+
+				// Dependent on whether the killer is still alive or not we have to be careful to not leak his player name
+				if(killedByActivePlayer.status.isActive()) {
+					description += ' killed by ' + NameManager.getInstance().getDisplayName(player.killedBy);
+				} else {
+					description += ' killed by ' + ParticipantEntityManager.getParticipantColoredBTagPrefixedWithOptionalTeamNumber(player.killedBy);
+				}
+
+				description += ' (' + (killedByActivePlayer.status ? killedByActivePlayer.status.status : 'Unknown') + ')';
+			}
 		});
 
 		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -181,7 +181,13 @@ export class Quests {
 		nameList.forEach((player) => {
 			description += `\n${nameManager.getBtag(player.getPlayer())}`;
 		});
-		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
+		this.BuildQuest(
+			'QUEST_SHUFFLED_PLAYER_LIST',
+			'Players',
+			description,
+			'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp',
+			false
+		);
 	}
 
 	public UpdateShuffledPlayerListQuest(): void {
@@ -200,6 +206,12 @@ export class Quests {
 			description += `\n${ParticipantEntityManager.getParticipantColoredBTagPrefixedWithOptionalTeamNumber(player.getPlayer())} (${player.status ? player.status.status : 'Unknown'})`;
 		});
 
-		this.BuildQuest('QUEST_SHUFFLED_PLAYER_LIST', 'Players', description, 'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp', false);
+		this.BuildQuest(
+			'QUEST_SHUFFLED_PLAYER_LIST',
+			'Players',
+			description,
+			'ReplaceableTextures\\CommandButtons\\BTNPeasant.blp',
+			false
+		);
 	}
 }

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -10,7 +10,6 @@ import { PromodeOptionsColorFormatted } from '../settings/strategies/promode-str
 import { HexColors } from '../utils/hex-colors';
 import { ParticipantEntityManager } from '../utils/participant-entity';
 import { ShuffleArray } from '../utils/utils';
-import { debugPrint } from '../utils/debug-print';
 
 /**
  * Responsible for creating in-game quests.
@@ -204,7 +203,7 @@ export class Quests {
 				const killedByActivePlayer = PlayerManager.getInstance().players.get(player.killedBy);
 
 				// Dependent on whether the killer is still alive or not we have to be careful to not leak his player name
-				if(killedByActivePlayer.status.isActive()) {
+				if (killedByActivePlayer.status.isActive()) {
 					description += ' killed by ' + NameManager.getInstance().getDisplayName(player.killedBy);
 				} else {
 					description += ' killed by ' + ParticipantEntityManager.getParticipantColoredBTagPrefixedWithOptionalTeamNumber(player.killedBy);

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -5,6 +5,9 @@ export const CITIES_TO_WIN_RATIO: number = 0.6;
 //This is the starting gold for each player. 4 gold by default.
 export const STARTING_INCOME: number = 4;
 
+//This is the starting countdown for the game. 10 by default
+export const STARTING_COUNTDOWN: number = 10;
+
 //This is the duration of a turn in seconds. 60 seconds by default.
 export const TURN_DURATION_IN_SECONDS: number = 60;
 
@@ -20,7 +23,7 @@ export const OVERTIME_MODIFIER: number = 1;
 //This represents the ratio of total cities to conquer to win.
 export const CITIES_TO_WIN_WARNING_RATIO: number = 0.7;
 
-//This represents the number of cities to conquer to win. Default is 22.
+//This represents the upper bound of cities a player starts with. Default is 22.
 export const CITIES_PER_PLAYER_UPPER_BOUND: number = 22;
 
 //This represents the duration a player can be muted for in seconds. Default is 300 seconds.

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,7 +134,7 @@ function tsMain() {
 			EventCoordinator.getInstance();
 			ModeSelection.getInstance();
 
-			Quests.getInstance().AddShuffledPlayerListQuest();
+			Quests.getInstance().addPlayersQuest();
 
 			//Export statistics
 			if (ENABLE_EXPORT_SHUFFLED_PLAYER_LIST) {


### PR DESCRIPTION
- Add player killer tracker -> #90 
- Add constant in game-settings for starting countdown (simplifies development)

Blocked/Based on #208 because I refactored parts of the quest tab there.

Here we have to be careful to not accidentally leak the player name, as long as the player is still active we use the color display name:

<img width="1218" height="804" alt="image" src="https://github.com/user-attachments/assets/815c5fa8-b708-4f95-af30-a46a7f3b031a" />

Once the player is dead, we switch to their original name:

<img width="1287" height="790" alt="image" src="https://github.com/user-attachments/assets/5ff110aa-7b93-4825-a599-41363eac25b9" />

We also show the killer in the GlobalMessage: 

<img width="1019" height="423" alt="image" src="https://github.com/user-attachments/assets/19f9313b-0144-49db-8024-ec0f048d46ec" />
