### PR TITLE
Pause disabled for FFA and Capitals once game has started

### DIFF
--- a/src/app/game/game-mode/base-game-mode/disable-pauses-state.ts
+++ b/src/app/game/game-mode/base-game-mode/disable-pauses-state.ts
@@ -1,0 +1,25 @@
+import { BaseState } from '../state/base-state';
+import { StateData } from '../state/state-data';
+
+export class DisablePausesState<T extends StateData> extends BaseState<T> {
+	onEnterState() {
+		this.runAsync();
+	}
+
+	async runAsync(): Promise<void> {
+		for (let i = 0; i < bj_MAX_PLAYERS; i++) {
+			const player = Player(i);
+
+			if (player == GetLocalPlayer()) {
+				for (let index = 0; index < 3; index++) {
+					PauseGame(true);
+					PauseGame(false);
+				}
+			}
+		}
+
+		ClearTextMessages();
+
+		this.nextState(this.stateData);
+	}
+}

--- a/src/app/game/game-mode/mode/capitals-mode.ts
+++ b/src/app/game/game-mode/mode/capitals-mode.ts
@@ -13,6 +13,7 @@ import { CapitalsGameLoopState } from '../capital-game-mode/capitals-game-loop-s
 import { CapitalsDistributeCapitalsState } from '../capital-game-mode/capitals-distribute-capitals-state';
 import { ApplyFogState } from '../base-game-mode/apply-fog-state';
 import { CapitalAssignCountrytNameState } from '../capital-game-mode/capital-assign-country-name-state';
+import { DisablePausesState } from '../base-game-mode/disable-pauses-state';
 
 export class CapitalsData implements StateData {
 	public playerCapitalSelections: Map<player, City>;
@@ -22,6 +23,7 @@ export class CapitalsData implements StateData {
 export class CapitalsMode extends BaseMode<CapitalsData> {
 	protected setupStates() {
 		return [
+			new DisablePausesState(),
 			new SetupState(),
 			new ApplyFogState(),
 			new CapitalsSelectionState(),

--- a/src/app/game/game-mode/mode/standard-mode.ts
+++ b/src/app/game/game-mode/mode/standard-mode.ts
@@ -9,12 +9,14 @@ import { BaseState } from '../state/base-state';
 import { StateData } from '../state/state-data';
 import { VisionState } from '../base-game-mode/vision-state';
 import { ApplyFogState } from '../base-game-mode/apply-fog-state';
+import { DisablePausesState } from '../base-game-mode/disable-pauses-state';
 
 export class StandardData implements StateData {}
 
 export class StandardMode extends BaseMode<StandardData> {
 	protected setupStates() {
 		return [
+			new DisablePausesState(),
 			new SetupState(),
 			new ApplyFogState(),
 			new CityDistributeState(),


### PR DESCRIPTION
This PR solves this issue by locally for each player repeatedly pausing and unpausing until their pauses have been exhausted. This also prevents them from pausing other players, as can be observed in this local multiplayer example:

# Red
<img width="1900" height="989" alt="WC3ScrnShot_083125_094627_000" src="https://github.com/user-attachments/assets/95b49815-f389-4dd9-8ddd-4c108a6c1fdc" />
<img width="1900" height="989" alt="WC3ScrnShot_083125_094645_000" src="https://github.com/user-attachments/assets/af46248d-b96b-40de-85df-9bec00753a73" />

# Blue
<img width="1900" height="989" alt="WC3ScrnShot_083125_094625_000" src="https://github.com/user-attachments/assets/199a8190-b768-4c8a-ab36-23c9bb6456e2" />
<img width="1900" height="989" alt="WC3ScrnShot_083125_094642_000" src="https://github.com/user-attachments/assets/96f8b30f-aa26-4b09-afd3-2b7a93344cd3" />

