### PR TITLE
Fix: Resolving city win bug

### DIFF
--- a/src/app/managers/victory-manager.ts
+++ b/src/app/managers/victory-manager.ts
@@ -60,31 +60,32 @@ export class VictoryManager {
 			return [];
 		}
 
-		let max = ParticipantEntityManager.getCityCount(
-			potentialVictors.sort((a, b) => ParticipantEntityManager.getCityCount(b) - ParticipantEntityManager.getCityCount(a))[0]
-		);
+		// potentialVictors is already sorted in descending order, so the first element has the max city count
+		let max = ParticipantEntityManager.getCityCount(potentialVictors[0]);
 		return potentialVictors.filter((x) => ParticipantEntityManager.getCityCount(x) == max);
 	}
 
 	public updateAndGetGameState(): VictoryProgressState {
-		// Quickly decide game is there is only one player or team alive
-		debugPrint('Checking if all opponents have been eliminated...');
+		// Check if there is only one player or team alive (this takes priority)
+		let eliminationVictory = false;
 		VictoryManager.getInstance().haveAllOpponentsBeenEliminated((participant) => {
 			GlobalGameData.leader = participant;
-			VictoryManager.GAME_VICTORY_STATE = 'DECIDED';
+			eliminationVictory = true;
 		});
 
-		if (VictoryManager.GAME_VICTORY_STATE === 'DECIDED') {
+		if (eliminationVictory) {
+			debugPrint('No opponents remain!');
+			VictoryManager.GAME_VICTORY_STATE = 'DECIDED';
 			return VictoryManager.GAME_VICTORY_STATE;
 		}
 
 		// Check if there is a city victory condition met
-		debugPrint('Checking for city count victory condition...');
 		let playerWinCandidates = this.victors();
 
 		if (playerWinCandidates.length == 0) {
 			VictoryManager.GAME_VICTORY_STATE = 'UNDECIDED';
 		} else if (playerWinCandidates.length == 1) {
+			debugPrint(ParticipantEntityManager.getDisplayName(playerWinCandidates[0]) + ' has met the city count victory condition!');
 			VictoryManager.GAME_VICTORY_STATE = 'DECIDED';
 		} else {
 			VictoryManager.GAME_VICTORY_STATE = 'TIE';


### PR DESCRIPTION
Bug Description: Once a player reaches the victory threshold (required number of cities), they continue to win at the end of the turn even if another player manages to capture their cities and reduce their count below the victory threshold during the same turn.

Root Cause: The updateAndGetGameState() method in VictoryManager had an early return that prevented re-evaluation of victory conditions once GAME_VICTORY_STATE was set to 'DECIDED'. This caused a "sticky victory" where the victory state persisted even when the actual game conditions changed.

Victory conditions should be dynamically re-evaluated each time updateAndGetGameState() is called, allowing the game state to change from 'DECIDED' back to 'UNDECIDED' if victory conditions are no longer met.

Removed the early return in updateAndGetGameState() that prevented re-evaluation
Modified the elimination victory check to use a local flag instead of relying on global state
Ensured that both elimination and city victory conditions are checked on every call