### PR TITLE
Fix missing country labels race condition in w3c client

### DIFF
--- a/src/app/game/mode-selection.ts
+++ b/src/app/game/mode-selection.ts
@@ -9,6 +9,7 @@ import { ENABLE_EXPORT_GAME_SETTINGS } from 'src/configs/game-settings';
 import { GameType } from 'src/app/settings/strategies/game-type-strategy';
 import { GlobalGameData } from './state/global-game-state';
 import { W3C_MODE_ENABLED } from '../utils/map-info';
+import { LocalMessage } from '../utils/messages';
 
 export class ModeSelection {
 	private ui: SettingsView;
@@ -33,6 +34,13 @@ export class ModeSelection {
 
 	public run(): void {
 		if (W3C_MODE_ENABLED) {
+			LocalMessage(
+				GetLocalPlayer(),
+				'Welcome to Risk Europe!\n\nThis is a best of 3 matchup. First to win 2 matches is victorious!\n\nBuild armies and capture countries to increase your income!\n\nPrevent your opponent from doing the same!\n\nGood luck and have fun!',
+				'Sound\\Interface\\ItemReceived.flac',
+				18
+			);
+
 			const settingsContext: SettingsContext = SettingsContext.getInstance();
 			settingsContext.getSettings().Promode = 1;
 			settingsContext.getSettings().GameType = 0;

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -30,7 +30,7 @@ export const CITIES_PER_PLAYER_UPPER_BOUND: number = 22;
 export const STFU_DURATION: number = 300;
 
 //This represents whether debug messages should be printed. Default is false.
-export const SHOW_DEBUG_PRINTS = true;
+export const SHOW_DEBUG_PRINTS = false;
 
 //This represents whether player names should be exported
 export const ENABLE_EXPORT_SHUFFLED_PLAYER_LIST: boolean = false;

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -30,7 +30,7 @@ export const CITIES_PER_PLAYER_UPPER_BOUND: number = 22;
 export const STFU_DURATION: number = 300;
 
 //This represents whether debug messages should be printed. Default is false.
-export const SHOW_DEBUG_PRINTS = false;
+export const SHOW_DEBUG_PRINTS = true;
 
 //This represents whether player names should be exported
 export const ENABLE_EXPORT_SHUFFLED_PLAYER_LIST: boolean = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,18 +141,9 @@ function tsMain() {
 				ExportShuffledPlayerList.write();
 			}
 
-			countryBuilder.createTexts();
-
-			EventEmitter.getInstance().emit(EVENT_MODE_SELECTION);
-
-			if (W3C_MODE_ENABLED) {
-				LocalMessage(
-					GetLocalPlayer(),
-					'Welcome to Risk Europe!\n\nThis is a best of 3 matchup. First to win 2 matches is victorious!\n\nBuild armies and capture countries to increase your income!\n\nPrevent your opponent from doing the same!\n\nGood luck and have fun!',
-					'Sound\\Interface\\ItemReceived.flac',
-					18
-				);
-			}
+			countryBuilder.createTexts().then(() => {
+				EventEmitter.getInstance().emit(EVENT_MODE_SELECTION);
+			});
 		});
 	} catch (e) {
 		print(e);


### PR DESCRIPTION
Currently, there is a race condition going on - main.ts is calling countryBuilder.createTexts() which is creating the texts for each country. However we don't wait for the completion of this and immediately jump into the event mode selection which also immediately jumps further because the settings in w3c are pre-set. This should fix the missing label issue in w3c because we explicitly wait for the completion of the generation of the country labels (which doesn't take long).