### PR TITLE
Refactor overtimes to 0 30 60 Off

### DIFF
--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -224,9 +224,9 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		SetPoint TOP,"PopupMenus",TOP,0.0,-0.12,
     	PopupMenuFrame "OvertimePopupMenu",
 			Frame "MENU" "OvertimePopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
-				MenuItem "Turbo (Turn 30)",     -2,
-				MenuItem "Medium (Turn 45)",     -2,
-				MenuItem "Long (Turn 60)",     -2,
+				MenuItem "Turbo (Turn 0)",     -2,
+				MenuItem "Medium (Turn 30)",     -2,
+				MenuItem "Extended (Turn 60)",     -2,
 				MenuItem "Off",     -2,
 			}
 		}

--- a/src/app/game/mode-selection.ts
+++ b/src/app/game/mode-selection.ts
@@ -57,7 +57,7 @@ export class ModeSelection {
 			settingsContext.getSettings().Promode = 0;
 			settingsContext.getSettings().Fog = 0;
 			settingsContext.getSettings().Diplomacy.option = 0;
-			settingsContext.getSettings().Overtime.option = 0;
+			settingsContext.getSettings().Overtime.option = 1;
 			this.ui.hide();
 			this.end();
 		} else {

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -105,9 +105,9 @@ export class Quests {
 		const description = `Overtime is a feature designed to help conclude games more efficiently by gradually reducing the number of cities required for victory. Once activated, each turn decreases the victory threshold by one city until a player wins.
 			
 			There are four Overtime settings:
-			1. Turbo Mode: Overtime begins at turn 30, accelerating the game pace early on. This is the default setting.
-			2. Medium Mode: Overtime starts at turn 45, allowing a longer game before the mechanic activates.
-			3. Long Mode: Overtime starts at turn 60, allowing for extended gameplay before the mechanic activates.
+			1. Turbo Mode: Overtime starts immediately, accelerating the game pace early on.
+			2. Medium Mode: Overtime starts at turn 30, allowing a longer game before the mechanic activates. This is the default setting.
+			3. Extended Mode: Overtime starts at turn 60, allowing for extended gameplay before the mechanic activates.
 			4. Off: Overtime is disabled.
 			
 			If two or more players exceed the city requirement to win while having the exact same number of cities, the game will be extended by additional turns until one player breaks the tie and leads in city count.

--- a/src/app/settings/settings-context.ts
+++ b/src/app/settings/settings-context.ts
@@ -30,7 +30,7 @@ export class SettingsContext {
 				Fog: 0,
 				Promode: 0,
 				Overtime: {
-					option: 0,
+					option: 1,
 				},
 			});
 		}

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -141,6 +141,11 @@ export class SettingsView {
 	}
 
 	private overtimePopup() {
+		// Initial setup
+		let popup = BlzGetFrameByName("OvertimePopup", 0)
+		BlzFrameSetValue(popup, 1)
+
+		// Create edit triggers
 		const t: trigger = CreateTrigger();
 
 		BlzTriggerRegisterFrameEvent(t, BlzGetFrameByName('OvertimePopup', 0), FRAMEEVENT_POPUPMENU_ITEM_CHANGED);

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -2,23 +2,23 @@ import { SettingsStrategy } from './settings-strategy';
 import { HexColors } from 'src/app/utils/hex-colors';
 import { OvertimeManager } from 'src/app/managers/overtime-manager';
 
-export type OvertimeSetting = 30 | 45 | 60 | undefined;
+export type OvertimeSetting = 0 | 30 | 60 | undefined;
 
 export interface OvertimeOptions {
 	option: number;
 }
 
 export const OvertimeStrings: Record<number, string> = {
-	0: `Turbo (Turn 30)`,
-	1: `Medium (Turn 45)`,
-	2: `Long (Turn 60)`,
+	0: `Turbo (Turn 0)`,
+	1: `Medium (Turn 30)`,
+	2: `Extended (Turn 60)`,
 	3: `Off`,
 };
 
 export const OvertimeColors: Record<number, string> = {
-	0: `${HexColors.GREEN}`,
-	1: `${HexColors.LIGHT_BLUE}`,
-	2: `${HexColors.BLUE}`,
+	0: `${HexColors.RED}`,
+	1: `${HexColors.GREEN}`,
+	2: `${HexColors.RED}`,
 	3: `${HexColors.RED}`,
 };
 
@@ -34,8 +34,8 @@ export class OvertimeStrategy implements SettingsStrategy {
 	private readonly strategyMap: Map<number, () => void> = new Map([
 		[0, this.handleTurboOption],
 		[1, this.handleMediumOption],
-		[2, this.handleLongOption],
-		[3, this.handleOff],
+		[2, this.handleExtendedOption],
+		[3, this.handleOffOption],
 	]);
 
 	constructor(overtime: OvertimeOptions) {
@@ -50,18 +50,18 @@ export class OvertimeStrategy implements SettingsStrategy {
 	}
 
 	private handleTurboOption(): void {
-		OvertimeManager.getInstance().setOvertimeSetting(30);
+		OvertimeManager.getInstance().setOvertimeSetting(0);
 	}
 
 	private handleMediumOption(): void {
-		OvertimeManager.getInstance().setOvertimeSetting(45);
+		OvertimeManager.getInstance().setOvertimeSetting(30);
 	}
 
-	private handleLongOption(): void {
+	private handleExtendedOption(): void {
 		OvertimeManager.getInstance().setOvertimeSetting(60);
 	}
 
-	private handleOff(): void {
+	private handleOffOption(): void {
 		OvertimeManager.getInstance().setOvertimeSetting(undefined);
 	}
 }


### PR DESCRIPTION
- Refactor overtime options to 0, 30, 60, Off
- Revert color change (think it made more sense before with red highlighting a change from the default setting)