### PR TITLE
fix: added colors

### DIFF
--- a/src/app/game/game-mode/base-game-mode/game-loop-state.ts
+++ b/src/app/game/game-mode/base-game-mode/game-loop-state.ts
@@ -267,6 +267,7 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 	}
 
 	onCityCapture(city: City, preOwner: ActivePlayer, owner: ActivePlayer): void {
+		super.onCityCapture(city, preOwner, owner);
 		ScoreboardManager.getInstance().updatePartial();
 		ScoreboardManager.getInstance().updateScoreboardTitle();
 	}

--- a/src/app/game/game-mode/state/base-state.ts
+++ b/src/app/game/game-mode/state/base-state.ts
@@ -12,6 +12,7 @@ import {
 	onPlayerNomadHandle,
 	onPlayerSTFUHandle,
 } from '../utillity/on-player-status';
+import { updateGold } from '../utillity/update-ui';
 
 export abstract class BaseState<T extends StateData> {
 	get stateData(): T {
@@ -55,7 +56,11 @@ export abstract class BaseState<T extends StateData> {
 		EventEmitter.getInstance().emit(EVENT_QUEST_UPDATE_PLAYER_STATUS);
 	}
 
-	onCityCapture(city: City, preOwner: ActivePlayer, owner: ActivePlayer) {}
+	onCityCapture(city: City, preOwner: ActivePlayer, owner: ActivePlayer) {
+		// Update soft gold cap display
+		updateGold(owner.getPlayer(), GetPlayerState(owner.getPlayer(), PLAYER_STATE_RESOURCE_GOLD));
+		updateGold(preOwner.getPlayer(), GetPlayerState(preOwner.getPlayer(), PLAYER_STATE_RESOURCE_GOLD));
+	}
 
 	onUnitKilled(killingUnit: unit, dyingUnit: unit) {}
 

--- a/src/app/game/game-mode/utillity/update-ui.ts
+++ b/src/app/game/game-mode/utillity/update-ui.ts
@@ -45,7 +45,29 @@ export function updateGold(player: player, goldAmount: number): void {
 	if (player == GetLocalPlayer()) {
 		const cap = IncomeManager.calculateGoldCap(PlayerManager.getInstance().players.get(player));
 		if (GetHandleId(customGoldText) !== 0) {
-			BlzFrameSetText(customGoldText, `${goldAmount}/${cap}`);
+			// Calculate percentage of cap
+			const percentage = (goldAmount / cap) * 100;
+			
+			// Determine colors based on percentage
+			let goldColor = HexColors.WHITE; // Default for < 75%
+			let capColor = HexColors.LIGHT_GRAY; // Default gray
+			
+			if (goldAmount > cap) {
+				// Above cap: red gold amount
+				goldColor = HexColors.RED;
+				capColor = HexColors.ORANGE;
+			} else if (percentage >= 90) {
+				// 90%+: white gold, orange cap
+				goldColor = HexColors.WHITE;
+				capColor = HexColors.ORANGE;
+			} else if (percentage >= 75) {
+				// 75%-89%: white gold, gray cap
+				goldColor = HexColors.WHITE;
+				capColor = HexColors.LIGHT_GRAY;
+			}
+			// else: < 75% uses defaults (white gold, gray cap)
+			
+			BlzFrameSetText(customGoldText, `${goldColor}${goldAmount}|r/${capColor}${cap}|r`);
 		}
 	}
 }


### PR DESCRIPTION
Cap is now updated on city capture/loss, and gold/cap are colored depending on their value and ratio.

<img width="540" height="372" alt="image" src="https://github.com/user-attachments/assets/a38e2413-cb3b-4e8a-97e0-57bbab62256d" />
