### PR TITLE
feat(unit-death): enhance unit search logic in EnemyKillHandler and S…

### DIFF
--- a/src/app/triggers/unit_death/enemy-kill-handler.ts
+++ b/src/app/triggers/unit_death/enemy-kill-handler.ts
@@ -20,6 +20,15 @@ export function EnemyKillHandler(city: City, dyingUnit: unit, killingUnit: unit)
 		return true;
 	}
 
+	//Search for city owned units within large radius of dying guard
+	GetUnitsInRangeByAllegiance(searchGroup, city, LargeSearchRadius, (unit, player) => UnitLagManager.IsUnitAlly(unit, player), dyingUnit);
+
+	if (BlzGroupGetSize(searchGroup) >= 1) {
+		ReplaceGuard(city, searchGroup);
+		DestroyGroup(searchGroup);
+		return true;
+	}
+
 	//No city owned units found, Search for allied units of killer in large radius of dying guard
 	GetUnitsInRangeOfUnitByAllegiance(
 		searchGroup,

--- a/src/app/triggers/unit_death/self-kill-handler.ts
+++ b/src/app/triggers/unit_death/self-kill-handler.ts
@@ -12,11 +12,23 @@ export function SelfKillHandler(city: City, dyingUnit: unit, killingUnit: unit):
 	const searchGroup: group = CreateGroup();
 
 	//Search for owned units in large radius of dying guard
-	GetUnitsInRangeByAllegiance(searchGroup, city, LargeSearchRadius, IsUnitOwnedByPlayer, dyingUnit);
+	GetUnitsInRangeByAllegiance(
+		searchGroup,
+		city,
+		LargeSearchRadius,
+		(u, p) => SharedSlotManager.getInstance().getOwnerOfUnit(u) === p,
+		dyingUnit
+	);
 
 	//Could not find valid units within large radius of guard, so we search in small radius by killer
 	if (BlzGroupGetSize(searchGroup) <= 0) {
-		GetUnitsInRangeByAllegiance(searchGroup, city, SmallSearchRadius, IsUnitOwnedByPlayer, killingUnit);
+		GetUnitsInRangeByAllegiance(
+			searchGroup,
+			city,
+			SmallSearchRadius,
+			(u, p) => SharedSlotManager.getInstance().getOwnerOfUnit(u) === p,
+			killingUnit
+		);
 	}
 
 	//Found valid guard units, set unit as guard


### PR DESCRIPTION
This pull request updates the logic for finding and replacing city guard units after a unit death, improving the accuracy of ownership checks and ensuring guards are replaced when appropriate. The main changes are as follows:

**Guard replacement logic improvements:**

* In `EnemyKillHandler`, after a guard is killed, the code now searches for city-owned units within a large radius and replaces the guard if any are found. This ensures city defense is maintained more reliably.
* In `SelfKillHandler`, the logic for determining unit ownership now uses `SharedSlotManager.getInstance().getOwnerOfUnit` for both large and small radius searches, making the ownership check more robust and consistent.…elfKillHandler for better unit identification