### PR TITLE
feat(game-loop): implement match loop management and player restart h…

### DIFF
--- a/src/app/game/game-mode/base-game-mode/game-loop-state.ts
+++ b/src/app/game/game-mode/base-game-mode/game-loop-state.ts
@@ -27,10 +27,16 @@ import { IncomeManager } from 'src/app/managers/income-manager';
 import { RatingManager } from 'src/app/rating/rating-manager';
 import { StatisticsController } from 'src/app/statistics/statistics-controller';
 import { applyEliminatedBuff } from '../utillity/on-player-status';
+import { EventEmitter } from 'src/app/utils/events/event-emitter';
+import { EVENT_ON_PLAYER_RESTART } from 'src/app/utils/events/event-constants';
 
 export class GameLoopState<T extends StateData> extends BaseState<T> {
+	private matchLoopTimer?: timer;
+	private hasFinishedMatchLoop = false;
+
 	onEnterState() {
 		GlobalGameData.matchState = 'inProgress';
+		this.hasFinishedMatchLoop = false;
 
 		// Capture initial game data for rating calculations
 		// This locks in player count and ratings at game start - never changes during game
@@ -49,20 +55,18 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 
 		this.onStartTurn(GlobalGameData.turnCount);
 
-		const _matchLoopTimer: timer = CreateTimer();
+		this.matchLoopTimer = CreateTimer();
 
 		updateTickUI();
 
-		TimerStart(_matchLoopTimer, TICK_DURATION_IN_SECONDS, true, () => {
+		TimerStart(this.matchLoopTimer, TICK_DURATION_IN_SECONDS, true, () => {
 			try {
 				// End game if only one player is remaining
 				this.endIfLastActivePlayer();
 
 				// Check if the match is over
 				if (this.isMatchOver()) {
-					PauseTimer(_matchLoopTimer);
-					DestroyTimer(_matchLoopTimer);
-					this.nextState(this.stateData);
+					this.finishMatchLoop();
 					return;
 				}
 
@@ -71,9 +75,7 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 
 				// Stop game loop if match is over
 				if (this.isMatchOver()) {
-					PauseTimer(_matchLoopTimer);
-					DestroyTimer(_matchLoopTimer);
-					this.nextState(this.stateData);
+					this.finishMatchLoop();
 					return;
 				}
 
@@ -91,6 +93,20 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 				if (DEBUG_PRINTS.master) debugPrint('Error in Timer ' + error, DC.gameMode);
 			}
 		});
+	}
+
+	private finishMatchLoop(): boolean {
+		if (this.hasFinishedMatchLoop) return false;
+		this.hasFinishedMatchLoop = true;
+
+		if (this.matchLoopTimer) {
+			PauseTimer(this.matchLoopTimer);
+			DestroyTimer(this.matchLoopTimer);
+			this.matchLoopTimer = undefined;
+		}
+
+		this.nextState(this.stateData);
+		return true;
 	}
 
 	endIfLastActivePlayer(): boolean {
@@ -344,9 +360,17 @@ export class GameLoopState<T extends StateData> extends BaseState<T> {
 	// GameLoopState uses GlobalGameData.matchState to determine if the match is over
 	// This is preferable as it allows the state to clean up and transition to the next state
 	onPlayerRestart(player: ActivePlayer) {
+		if (GlobalGameData.matchState === 'postMatch') {
+			if (this.finishMatchLoop()) {
+				EventEmitter.getInstance().emit(EVENT_ON_PLAYER_RESTART, player);
+			}
+			return;
+		}
+
 		const humanPlayersCount: number = PlayerManager.getInstance().getHumanPlayersCount();
 		if (humanPlayersCount === 1) {
 			GlobalGameData.matchState = 'postMatch';
+			this.finishMatchLoop();
 		}
 	}
 

--- a/tests/game-simulation/restart-race.test.ts
+++ b/tests/game-simulation/restart-race.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import './helpers/wc3-integration-shim';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+vi.mock('w3ts', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('w3ts/system/file', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('src/app/country/country-map', () => ({
+	StringToCountry: new Map(),
+	CityToCountry: new Map(),
+}));
+
+vi.mock('src/app/game/game-mode/utillity/update-ui', () => ({
+	updateTickUI: vi.fn(),
+}));
+
+vi.mock('src/app/game/announcer/announce', () => ({
+	AnnounceOnLocation: vi.fn(),
+}));
+
+vi.mock('src/app/game/game-mode/utillity/on-player-status', () => ({
+	onPlayerAliveHandle: vi.fn(),
+	onPlayerDeadHandle: vi.fn(),
+	onPlayerLeftHandle: vi.fn(),
+	onPlayerNomadHandle: vi.fn(),
+	onPlayerSTFUHandle: vi.fn(),
+	applyEliminatedBuff: vi.fn(),
+}));
+
+vi.mock('src/app/game/services/shared-slot-manager', () => ({
+	SharedSlotManager: {
+		getInstance: () => ({
+			evaluateAndRedistribute: () => false,
+			debugPrintSlotCounts: vi.fn(),
+			getOwnerOfUnit: (unit: any) => unit?.owner,
+		}),
+	},
+}));
+
+vi.mock('src/app/managers/income-manager', () => ({
+	IncomeManager: { giveIncome: vi.fn() },
+}));
+
+vi.mock('src/app/managers/fog-manager', () => ({
+	FogManager: {
+		getInstance: () => ({
+			turnFogOff: vi.fn(),
+			turnFogOn: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/managers/victory-manager', () => ({
+	VictoryManager: {
+		GAME_VICTORY_STATE: 'UNDECIDED',
+		getInstance: () => ({
+			haveAllOpponentsBeenEliminated: vi.fn(),
+			updateAndGetGameState: vi.fn(),
+			getOwnershipByThresholdDescending: () => [],
+			getCityCountWin: () => 10,
+		}),
+	},
+}));
+
+vi.mock('src/app/scoreboard/scoreboard-manager', () => ({
+	ScoreboardManager: {
+		getInstance: () => ({
+			updateFull: vi.fn(),
+			updatePartial: vi.fn(),
+			updateScoreboardTitle: vi.fn(),
+			destroyBoards: vi.fn(),
+			getSessionBoard: () => null,
+			showSessionBoard: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/statistics/statistics-controller', () => ({
+	StatisticsController: {
+		getInstance: () => ({
+			getModel: () => ({ setData: vi.fn(), getRanks: () => [] }),
+			refreshView: vi.fn(),
+			setViewVisibility: vi.fn(),
+			writeStatisticsData: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/statistics/replay-manager', () => ({
+	ReplayManager: {
+		getInstance: () => ({
+			onRoundStart: vi.fn(),
+			onTurnStart: vi.fn(),
+			onRoundEnd: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/rating/rating-manager', () => ({
+	RatingManager: {
+		getInstance: () => ({
+			isRankedGame: () => false,
+			captureInitialGameData: vi.fn(),
+			saveRatingsInProgress: vi.fn(),
+			finalizePlayerRating: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/player/player-manager', () => ({
+	PlayerManager: {
+		getInstance: vi.fn(),
+	},
+}));
+
+vi.mock('src/app/settings/settings-context', () => ({
+	SettingsContext: {
+		getInstance: vi.fn(),
+	},
+}));
+
+vi.mock('src/app/managers/names/name-manager', () => ({
+	NameManager: {
+		getInstance: () => ({
+			setColor: vi.fn(),
+			setName: vi.fn(),
+			getOriginalColor: () => 0,
+			getDisplayName: () => 'Player',
+		}),
+	},
+}));
+
+vi.mock('src/app/quests/quests', () => ({
+	Quests: {
+		getInstance: () => ({
+			updatePlayersQuest: vi.fn(),
+		}),
+	},
+}));
+
+vi.mock('src/app/utils/messages', () => ({
+	GlobalMessage: vi.fn(),
+	LocalMessage: vi.fn(),
+}));
+
+vi.mock('src/app/utils/utils', () => ({
+	PlayLocalSound: vi.fn(),
+}));
+
+vi.mock('src/app/utils/player-colors', () => ({
+	PLAYER_COLOR_CODES_MAP: new Map(),
+}));
+
+import { GameLoopState } from 'src/app/game/game-mode/base-game-mode/game-loop-state';
+import { GameOverState } from 'src/app/game/game-mode/base-game-mode/game-over-state';
+import { GlobalGameData } from 'src/app/game/state/global-game-state';
+import { PlayerManager } from 'src/app/player/player-manager';
+import { SettingsContext } from 'src/app/settings/settings-context';
+import { EVENT_ON_PLAYER_RESTART } from 'src/app/utils/events/event-constants';
+import { EventEmitter } from 'src/app/utils/events/event-emitter';
+
+describe('immediate restart after match end', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		GlobalGameData.resetInstance();
+		EventEmitter.resetInstance();
+
+		vi.mocked(PlayerManager.getInstance).mockReturnValue({
+			getHumanPlayersCount: () => 2,
+			activePlayersThatAreAlive: new Map(),
+		} as any);
+
+		vi.mocked(SettingsContext.getInstance).mockReturnValue({
+			isFFA: () => false,
+			isPromode: () => true,
+			isChaosPromode: () => false,
+			isRandomTeams: () => false,
+		} as any);
+	});
+
+	it('exits the game loop and replays -ng when -ff already moved matchState to postMatch', () => {
+		const state = new GameLoopState();
+		state.stateData = {};
+		const order: string[] = [];
+		state.nextState = vi.fn(() => order.push('game-over-entered'));
+		EventEmitter.getInstance().on(EVENT_ON_PLAYER_RESTART, () => order.push('restart-replayed'));
+		GlobalGameData.matchState = 'postMatch';
+
+		state.onPlayerRestart({} as any);
+
+		expect(state.nextState).toHaveBeenCalledTimes(1);
+		expect(state.nextState).toHaveBeenCalledWith(state.stateData);
+		expect(order).toEqual(['game-over-entered', 'restart-replayed']);
+	});
+
+	it('guards the game-loop exit so repeated -ng cannot double-advance the state machine', () => {
+		const state = new GameLoopState();
+		state.stateData = {};
+		state.nextState = vi.fn();
+		GlobalGameData.matchState = 'postMatch';
+
+		state.onPlayerRestart({} as any);
+		state.onPlayerRestart({} as any);
+
+		expect(state.nextState).toHaveBeenCalledTimes(1);
+	});
+
+	it('replayed -ng can be handled by GameOverState after end-of-match work runs', () => {
+		const loopState = new GameLoopState();
+		const gameOverState = new GameOverState();
+		const stateData = {};
+		const order: string[] = [];
+
+		loopState.stateData = stateData;
+		gameOverState.stateData = stateData;
+		loopState.nextState = vi.fn(() => {
+			order.push('game-over-entered');
+			gameOverState.onEnterState();
+		});
+		gameOverState.nextState = vi.fn(() => order.push('reset-started'));
+		EventEmitter.getInstance().on(EVENT_ON_PLAYER_RESTART, (player) => gameOverState.onPlayerRestart(player));
+
+		GlobalGameData.matchState = 'postMatch';
+
+		loopState.onPlayerRestart({} as any);
+
+		expect(order).toEqual(['game-over-entered', 'reset-started']);
+		expect(gameOverState.nextState).toHaveBeenCalledWith(stateData);
+	});
+});


### PR DESCRIPTION
This pull request improves the robustness of the game loop state transition logic, especially around handling player restarts at the end of a match, and adds comprehensive tests for these scenarios. The main changes include refactoring the game loop timer cleanup, preventing duplicate state transitions, and introducing new tests to ensure correct behavior when a player restarts after the match ends.

**Game loop state management improvements:**

* Refactored `GameLoopState` to track and clean up the match loop timer with a new `finishMatchLoop()` method, ensuring timers are paused and destroyed only once and preventing duplicate state transitions. (`src/app/game/game-mode/base-game-mode/game-loop-state.ts`) [[1]](diffhunk://#diff-0287cc79f603b5dc1ddad7c422f71785d8759cc3a5183279f046136f4bfdb48aR30-R39) [[2]](diffhunk://#diff-0287cc79f603b5dc1ddad7c422f71785d8759cc3a5183279f046136f4bfdb48aL52-R69) [[3]](diffhunk://#diff-0287cc79f603b5dc1ddad7c422f71785d8759cc3a5183279f046136f4bfdb48aL74-R78) [[4]](diffhunk://#diff-0287cc79f603b5dc1ddad7c422f71785d8759cc3a5183279f046136f4bfdb48aR98-R111)
* Updated `onPlayerRestart` to use `finishMatchLoop()` and emit a restart event only if the match loop has not already finished, ensuring safe handling of repeated restarts and avoiding double advancement of the state machine. (`src/app/game/game-mode/base-game-mode/game-loop-state.ts`)

**Testing enhancements:**

* Added a new test suite `restart-race.test.ts` that mocks all major game dependencies and verifies:
  - The game loop exits and emits events correctly when a restart occurs after the match ends.
  - The state machine is guarded against double-advancing on repeated restarts.
  - The restart event can be handled by subsequent states (e.g., `GameOverState`) after end-of-match logic. (`tests/game-simulation/restart-race.test.ts`)…andling