### PR TITLE
Features/fix colors

### DIFF
--- a/src/app/city/city.ts
+++ b/src/app/city/city.ts
@@ -8,6 +8,7 @@ import { UNIT_TYPE } from '../utils/unit-types';
 import { UNIT_ID } from 'src/configs/unit-id';
 import { ABILITY_ID } from 'src/configs/ability-id';
 import { SharedSlotManager } from '../game/services/shared-slot-manager';
+import { AllyColorFilterManager } from '../managers/ally-color-filter-manager';
 
 /**
  * Abstract class for a City.
@@ -68,6 +69,13 @@ export abstract class City implements Resetable, Ownable {
 		this.owner = player;
 		this._barrack.setOwner(player);
 		SetUnitOwner(this._cop, player, true);
+		this.applyColorFilter();
+	}
+
+	private applyColorFilter(): void {
+		const colorFilter = AllyColorFilterManager.getInstance();
+		colorFilter.applyColorFilter(this._barrack.unit);
+		colorFilter.applyColorFilter(this._cop);
 	}
 
 	/**

--- a/src/app/game/services/unit-lag-manager.ts
+++ b/src/app/game/services/unit-lag-manager.ts
@@ -35,13 +35,6 @@ export class UnitLagManager {
 			return;
 		}
 
-		// Only shared slots need their units tracked/fixed.
-		// Exception: transports are always owned by the real player slot (not a shared slot),
-		// but still need custom minimap tracking so they retain the player's color.
-		if (!SharedSlotManager.getInstance().isAnySharedSlotOwnerOfUnit(unit) && !IsUnitType(unit, UNIT_TYPE.TRANSPORT)) {
-			return;
-		}
-
 		// Color the unit to match the real owner instead of using SetPlayerColor (which corrupts WC3 native End-Game screen)
 		//const realOwner = SharedSlotManager.getInstance().getOwnerOfUnit(unit);
 

--- a/src/app/managers/alliances/ally-color-state.ts
+++ b/src/app/managers/alliances/ally-color-state.ts
@@ -40,6 +40,10 @@ export class AllyColorState {
 		return IsPlayerAlly(player, localPlayer);
 	}
 
+	isNeutral(player: any): boolean {
+		return GetPlayerId(player) >= bj_MAX_PLAYERS;
+	}
+
 	getDefaultColor(player: any): any {
 		return GetPlayerColor(player);
 	}
@@ -61,6 +65,9 @@ export class AllyColorState {
 	}
 
 	private resolveTeamColor(player: any, localPlayer: any, isColorBlind?: boolean): any {
+		if (this.isNeutral(player)) {
+			return this.getDefaultColor(player);
+		}
 		if (player === localPlayer) {
 			return this.getBlue();
 		}

--- a/src/app/managers/ally-color-filter-manager.ts
+++ b/src/app/managers/ally-color-filter-manager.ts
@@ -197,12 +197,16 @@ export class AllyColorFilterManager {
 		const cacheData = this.cache[playerId];
 
 		if (cacheData) {
+			// Player colors are assigned after this manager is constructed, so normal
+			// color modes must read the live engine color instead of the startup cache.
+			const unitColor = AllyColorState.getInstance().getMode() === 2 ? cacheData.color : GetPlayerColor(owner);
+
 			if (isSpawn) {
 				SetUnitVertexColor(u, cacheData.spawnRed, cacheData.spawnGreen, cacheData.spawnBlue, alpha);
 			} else {
 				SetUnitVertexColor(u, cacheData.red, cacheData.green, cacheData.blue, alpha);
 			}
-			SetUnitColor(u, cacheData.color);
+			SetUnitColor(u, unitColor);
 		}
 	}
 

--- a/src/app/managers/ally-color-filter-manager.ts
+++ b/src/app/managers/ally-color-filter-manager.ts
@@ -69,6 +69,9 @@ export class AllyColorFilterManager {
 					for (const u of activePlayer.trackedData.units) {
 						this.applyColorFilter(u);
 					}
+					for (const u of activePlayer.trackedData.transports) {
+						this.applyColorFilter(u);
+					}
 				}
 
 				for (const [city] of CityToCountry) {

--- a/src/app/managers/minimap-icon-manager.ts
+++ b/src/app/managers/minimap-icon-manager.ts
@@ -940,7 +940,7 @@ export class MinimapIconManager {
 	private updateUnitIconColor(iconFrame: framehandle, unit: unit, localPlayer: player): void {
 		// Used the SharedSlotManager to resolve the real owner (maps SharedSlot -> Player)
 		const owner = SharedSlotManager.getInstance().getOwnerOfUnit(unit);
-		let allyColorMode = GetAllyColorFilterState();
+		let allyColorMode = AllyColorState.getInstance().getMode();
 		const activeLocalPlayerForColor = PlayerManager.getInstance().players.get(localPlayer);
 		if (activeLocalPlayerForColor && activeLocalPlayerForColor.options.colorContrast) {
 			allyColorMode = 2;

--- a/src/app/managers/minimap-icon-manager.ts
+++ b/src/app/managers/minimap-icon-manager.ts
@@ -211,16 +211,11 @@ export class MinimapIconManager {
 	 *Safe to call with any unit.
 	 * @param unit - The unit to check and potentially track
 	 */
-	public registerIfValid(unit: unit): void {
+	public registerIfValid(unit: unit, forceIconRefresh: boolean = false): void {
 		if (!this.isActive) return;
 
 		// Don't track if unit is already dead
 		if (!UnitAlive(unit)) {
-			return;
-		}
-
-		// Only track units marked as SPAWN
-		if (!IsUnitType(unit, UNIT_TYPE.SPAWN)) {
 			return;
 		}
 
@@ -232,6 +227,10 @@ export class MinimapIconManager {
 		// Check if already tracked to avoid duplicates
 		if (!this.trackedList.trackedUnitIndex.has(unit)) {
 			this.registerTrackedUnit(unit);
+		}
+
+		if (forceIconRefresh) {
+			this.refreshTrackedUnitIcon(unit);
 		}
 	}
 
@@ -339,6 +338,37 @@ export class MinimapIconManager {
 		} catch (e) {
 			if (DEBUG_PRINTS.master) debugPrint('MinimapIconManager: Error registering unit - ' + e, DC.minimap);
 		}
+	}
+
+	/**
+	 * Forces a tracked unit's custom minimap icon to recompute its current texture.
+	 * Use this after lifecycle events like transport unloading where a recycled
+	 * frame may still display an old texture even though the unit's cache looks current.
+	 */
+	private refreshTrackedUnitIcon(unit: unit): void {
+		if (!this.isActive) return;
+
+		const index = this.trackedList.trackedUnitIndex.get(unit);
+		if (index === undefined) {
+			return;
+		}
+
+		const iconFrame = this.trackedList.trackedFrameList[index];
+		const localPlayer = GetLocalPlayer();
+		const effectiveLocal = isReplay() ? getReplayObservedPlayer() : localPlayer;
+
+		this.unitLastTexture.delete(unit);
+
+		if (!IsUnitVisible(unit, effectiveLocal)) {
+			this.trackedList.trackedRawOwnerList[index] = Player(25);
+			BlzFrameSetVisible(iconFrame, false);
+			return;
+		}
+
+		this.updateIconPosition(iconFrame, GetUnitX(unit), GetUnitY(unit));
+		this.updateUnitIconColor(iconFrame, unit, effectiveLocal);
+		this.trackedList.trackedRawOwnerList[index] = GetOwningPlayer(unit);
+		BlzFrameSetVisible(iconFrame, true);
 	}
 
 	/**

--- a/src/app/managers/transport-manager.ts
+++ b/src/app/managers/transport-manager.ts
@@ -220,7 +220,7 @@ export class TransportManager {
 			if (!UnitAlive(unit) || IsUnitType(unit, UNIT_TYPE.GUARD) || IsUnitLoaded(unit)) continue;
 
 			UnitLagManager.getInstance().trackUnit(unit);
-			MinimapIconManager.getInstance().registerIfValid(unit);
+			MinimapIconManager.getInstance().registerIfValid(unit, true);
 			AllyColorFilterManager.getInstance().applyColorFilter(unit);
 		}
 		TransportManager.delayedTrackQueue.length = 0;
@@ -259,7 +259,7 @@ export class TransportManager {
 			// Track all cargo units (shared slots) again since the transport is dead
 			transportData.cargo.forEach((unit) => {
 				UnitLagManager.getInstance().trackUnit(unit);
-				MinimapIconManager.getInstance().registerIfValid(unit);
+				MinimapIconManager.getInstance().registerIfValid(unit, true);
 				AllyColorFilterManager.getInstance().applyColorFilter(unit);
 			});
 		}

--- a/src/app/player/data/tracked-data.ts
+++ b/src/app/player/data/tracked-data.ts
@@ -23,6 +23,7 @@ export class TrackedData {
 
 	private _lastUnitKilledBy: player;
 	private _units: Set<unit>;
+	private _transports: Set<unit>;
 	private _turnDied: number;
 	private _trainedUnits: Map<number, number>;
 
@@ -52,6 +53,7 @@ export class TrackedData {
 		this._roarCasts = 0;
 		this._dispelCasts = 0;
 		this._units = new Set<unit>();
+		this._transports = new Set<unit>();
 		this._trainedUnits = new Map<number, number>();
 		this._turnDied = -1;
 		this._lastUnitKilledBy = undefined;
@@ -76,6 +78,7 @@ export class TrackedData {
 		this.roarCasts = 0;
 		this.dispelCasts = 0;
 		this.units.clear();
+		this.transports.clear();
 		this._trainedUnits.clear();
 		this.turnDied = 0;
 		this._lastUnitKilledBy = undefined;
@@ -148,6 +151,11 @@ export class TrackedData {
 
 	public get units(): Set<unit> {
 		return this._units;
+	}
+
+	// Transports are tracked separately from other units since they have different implications for gameplay (victory conditions) and statistics.
+	public get transports(): Set<unit> {
+		return this._transports;
 	}
 
 	public get denies(): number {

--- a/src/app/player/types/human-player.ts
+++ b/src/app/player/types/human-player.ts
@@ -41,8 +41,9 @@ export class HumanPlayer extends ActivePlayer {
 
 	onDeath(killer: player, unit: unit, isPlayerCombat: boolean): void {
 		this.trackedData.units.delete(unit);
+		this.trackedData.transports.delete(unit);
 
-		if(isPlayerCombat) {
+		if (isPlayerCombat) {
 			this.trackedData.lastUnitKilledBy = killer;
 		}
 

--- a/src/app/triggers/unit-trained-event.ts
+++ b/src/app/triggers/unit-trained-event.ts
@@ -67,7 +67,9 @@ export function UnitTrainedEvent() {
 
 			const player: ActivePlayer = PlayerManager.getInstance().players.get(realOwner);
 
-			if (!IsUnitType(trainedUnit, UNIT_TYPE.TRANSPORT)) {
+			if (IsUnitType(trainedUnit, UNIT_TYPE.TRANSPORT)) {
+				player.trackedData.transports.add(trainedUnit);
+			} else {
 				player.trackedData.units.add(trainedUnit);
 			}
 

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,7 +1,7 @@
 
 	//Do not edit - this will automatically update based on the project config.json upon building the map
 	export const MAP_NAME: string = 'Risk Europe';
-	export const MAP_VERSION: string = '4.09-unstable6';
+	export const MAP_VERSION: string = 'dev';
 	export const MAP_TYPE: string = 'europe';
 	export const W3C_MODE_ENABLED: boolean = false;
   

--- a/tests/ally-color-mode-logic.test.ts
+++ b/tests/ally-color-mode-logic.test.ts
@@ -10,6 +10,10 @@ import { AllyColorState, PlayerSettings } from '../src/app/managers/alliances/al
 globalThis.GetLocalPlayer = vi.fn(() => null);
 // @ts-expect-error Mocking global function
 globalThis.IsPlayerObserver = vi.fn(() => false);
+// @ts-expect-error Mocking global function
+globalThis.GetPlayerId = vi.fn((player: unknown) => (typeof player === 'number' ? player : ((player as { id?: number })?.id ?? 0)));
+// @ts-expect-error Mocking global value
+globalThis.bj_MAX_PLAYERS = 24;
 
 describe('AllyColorState', () => {
 	let settings: PlayerSettings;

--- a/tests/ally-color-mode-logic.test.ts
+++ b/tests/ally-color-mode-logic.test.ts
@@ -76,6 +76,7 @@ describe('AllyColorState', () => {
 		const P_LOCAL = 1;
 		const P_ALLY = 2;
 		const P_ENEMY = 3;
+		const P_NEUTRAL = 24;
 
 		it('returns colors correctly in Mode 0', () => {
 			expect(allyColorState.getMinimapColor(P_LOCAL, P_LOCAL)).toBe(defaultColor);
@@ -119,6 +120,19 @@ describe('AllyColorState', () => {
 			allyColorState.toggle(); // Mode 2
 			expect(allyColorState.getMinimapColor(P_ALLY, P_LOCAL, true)).toBe(yellow);
 			expect(allyColorState.getUnitModelColor(P_ALLY, P_LOCAL, true)).toBe(yellow);
+		});
+
+		it('keeps neutral player colors in ally color modes', () => {
+			const stateWithNeutralCheck = allyColorState as AllyColorState & { isNeutral: (player: number) => boolean };
+			stateWithNeutralCheck.isNeutral = vi.fn((player) => player === P_NEUTRAL);
+
+			allyColorState.toggle(); // Mode 1
+			expect(allyColorState.getMinimapColor(P_NEUTRAL, P_LOCAL)).toBe(defaultColor);
+			expect(allyColorState.getUnitModelColor(P_NEUTRAL, P_LOCAL)).toBe(defaultColor);
+
+			allyColorState.toggle(); // Mode 2
+			expect(allyColorState.getMinimapColor(P_NEUTRAL, P_LOCAL)).toBe(defaultColor);
+			expect(allyColorState.getUnitModelColor(P_NEUTRAL, P_LOCAL)).toBe(defaultColor);
 		});
 	});
 });

--- a/tests/game-simulation/ally-color-filter-manager.test.ts
+++ b/tests/game-simulation/ally-color-filter-manager.test.ts
@@ -72,6 +72,7 @@ describe('AllyColorFilterManager', () => {
 		// Mock PlayerManager
 		activeLocalPlayer = {
 			options: { colorblind: false, colorContrast: true },
+			trackedData: { units: new Set(), transports: new Set() },
 		};
 		const pmMock = {
 			players: new Map([[localPlayer, activeLocalPlayer]]),
@@ -217,6 +218,25 @@ describe('AllyColorFilterManager', () => {
 
 			// restore
 			(globalThis as any).Player = originalPlayerFunc;
+		});
+	});
+
+	describe('startPolling', () => {
+		it('reapplies color filters to tracked transports when color mode state changes', () => {
+			let pollCallback: () => void = () => {};
+			(globalThis as any).CreateTimer = () => ({});
+			(globalThis as any).TimerStart = (_timer: any, _timeout: number, _periodic: boolean, callback: () => void) => {
+				pollCallback = callback;
+			};
+			mockAllyColorFilterState = 0;
+
+			const transport = { owner: enemyPlayer, typeIds: [UNIT_TYPE.TRANSPORT] } as unknown as FakeUnitHandle;
+			activeLocalPlayer.trackedData.transports.add(transport as any);
+
+			AllyColorFilterManager.getInstance().startPolling();
+			pollCallback();
+
+			expect(mockVertexColors.get(transport)).toEqual({ r: 255, g: 50, b: 50, a: 255 });
 		});
 	});
 });

--- a/tests/game-simulation/ally-color-filter-manager.test.ts
+++ b/tests/game-simulation/ally-color-filter-manager.test.ts
@@ -12,6 +12,7 @@ vi.mock('w3ts/system/file', () => ({
 // ────────────────────────────────────────────────────────────────────
 
 import { AllyColorFilterManager } from '../../src/app/managers/ally-color-filter-manager';
+import { AllyColorState } from '../../src/app/managers/alliances/ally-color-state';
 import { SharedSlotManager } from '../../src/app/game/services/shared-slot-manager';
 import { PlayerManager } from '../../src/app/player/player-manager';
 import { UNIT_TYPE } from '../../src/app/utils/unit-types';
@@ -33,6 +34,7 @@ describe('AllyColorFilterManager', () => {
 		// Reset singletons
 		(SharedSlotManager as any).instance = undefined;
 		(PlayerManager as any).instance = undefined;
+		(AllyColorState as any).instance = undefined;
 
 		// Mock WC3 globals for this test
 		localPlayer = { id: 0, isFakePlayerHandle: true } as any;
@@ -50,6 +52,7 @@ describe('AllyColorFilterManager', () => {
 
 		mockVertexColors = new Map();
 		mockUnitColors = new Map();
+		(globalThis as any).GetPlayerColor = (p: any) => p?.color ?? p?.id ?? 0;
 		(globalThis as any).SetUnitColor = (u: any, c: any) => mockUnitColors.set(u, c);
 		(globalThis as any).SetUnitVertexColor = (u: any, r: number, g: number, b: number, a: number) => {
 			mockVertexColors.set(u, { r, g, b, a });
@@ -121,6 +124,36 @@ describe('AllyColorFilterManager', () => {
 			AllyColorFilterManager.getInstance().recalculate();
 			const unit = { owner: enemyPlayer } as unknown as FakeUnitHandle;
 			AllyColorFilterManager.getInstance().applyColorFilter(unit as any);
+			expect(mockVertexColors.get(unit)).toEqual({ r: 255, g: 255, b: 255, a: 255 });
+		});
+
+		it('uses current player colors when colors change after the cache is created', () => {
+			activeLocalPlayer.options.colorContrast = false;
+			const bluePlayer = Player(1) as any;
+			bluePlayer.color = 'PURPLE_BEFORE_RANDOMIZATION';
+
+			const manager = AllyColorFilterManager.getInstance();
+			bluePlayer.color = 'BLUE_AFTER_RANDOMIZATION';
+
+			const unit = { owner: bluePlayer } as unknown as FakeUnitHandle;
+			manager.applyColorFilter(unit as any);
+
+			expect(mockUnitColors.get(unit)).toBe('BLUE_AFTER_RANDOMIZATION');
+		});
+
+		it('keeps neutral units neutral in custom ally mode 2', () => {
+			activeLocalPlayer.options.colorContrast = false;
+			neutralHostilePlayer.color = 'NEUTRAL_COLOR';
+			(AllyColorState as any).instance = new AllyColorState({
+				loadMode: () => 2,
+				saveMode: vi.fn(),
+			});
+			(AllyColorFilterManager as any).instance = undefined;
+
+			const unit = { owner: neutralHostilePlayer } as unknown as FakeUnitHandle;
+			AllyColorFilterManager.getInstance().applyColorFilter(unit as any);
+
+			expect(mockUnitColors.get(unit)).toBe('NEUTRAL_COLOR');
 			expect(mockVertexColors.get(unit)).toEqual({ r: 255, g: 255, b: 255, a: 255 });
 		});
 	});

--- a/tests/game-simulation/city-color-filter.test.ts
+++ b/tests/game-simulation/city-color-filter.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import './helpers/wc3-integration-shim';
+
+vi.mock('src/app/game/services/shared-slot-manager', () => ({
+	SharedSlotManager: {
+		getInstance: () => ({
+			getOwnerOfUnit: (unit: any) => unit.owner,
+		}),
+	},
+}));
+
+vi.mock('src/app/managers/ally-color-filter-manager', () => ({
+	AllyColorFilterManager: {
+		getInstance: vi.fn(),
+	},
+}));
+
+import { City } from 'src/app/city/city';
+import { AllyColorFilterManager } from 'src/app/managers/ally-color-filter-manager';
+
+class TestCity extends City {
+	isValidGuard(): boolean {
+		return true;
+	}
+
+	onUnitTrain(): void {}
+
+	onCast(): void {}
+
+	isPort(): boolean {
+		return false;
+	}
+
+	isCapital(): boolean {
+		return false;
+	}
+}
+
+describe('City color filter', () => {
+	let applyColorFilter: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		applyColorFilter = vi.fn();
+		vi.mocked(AllyColorFilterManager.getInstance).mockReturnValue({
+			applyColorFilter,
+		} as any);
+	});
+
+	it('reapplies the current color filter synchronously when ownership changes', () => {
+		const owner = Player(1);
+		const barrackUnit = { owner: Player(24) };
+		const cop = { owner: Player(24) };
+		const guardUnit = { owner };
+		const barrack = {
+			unit: barrackUnit,
+			defaultX: 0,
+			defaultY: 0,
+			setOwner: vi.fn((player: player) => {
+				barrackUnit.owner = player;
+			}),
+		};
+		const guard = { unit: guardUnit };
+		const city = new TestCity(barrack as any, guard as any, cop as any);
+
+		city.setOwner(owner);
+
+		expect(applyColorFilter).toHaveBeenCalledTimes(2);
+		expect(applyColorFilter.mock.calls[0][0]).toBe(barrackUnit);
+		expect(applyColorFilter.mock.calls[1][0]).toBe(cop);
+	});
+});

--- a/tests/game-simulation/helpers/setup.ts
+++ b/tests/game-simulation/helpers/setup.ts
@@ -67,6 +67,7 @@ export function createFakeActivePlayer(playerId: number): any {
 		roarCasts: 0,
 		dispelCasts: 0,
 		units: new Set(),
+		transports: new Set(),
 		trainedUnits: new Map(),
 		turnDied: -1,
 		lastUnitKilledBy: undefined,
@@ -80,6 +81,7 @@ export function createFakeActivePlayer(playerId: number): any {
 			this.countries.clear();
 			this.killsDeaths.clear();
 			this.units.clear();
+			this.transports.clear();
 		},
 		setKDMaps() {},
 	};

--- a/tests/game-simulation/minimap-icon-manager-color.test.ts
+++ b/tests/game-simulation/minimap-icon-manager-color.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import './helpers/wc3-integration-shim';
+
+vi.mock('w3ts', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('w3ts/system/file', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('src/app/player/player-manager', () => ({
+	PlayerManager: {
+		getInstance: vi.fn(),
+	},
+}));
+
+vi.mock('src/app/game/services/shared-slot-manager', () => ({
+	SharedSlotManager: {
+		getInstance: vi.fn(),
+	},
+}));
+
+vi.mock('src/app/managers/names/name-manager', () => ({
+	NameManager: {
+		getInstance: () => ({
+			getOriginalColor: (p: any) => p?.color ?? p?.id ?? 0,
+		}),
+	},
+}));
+
+vi.mock('src/app/settings/settings-context', () => ({
+	SettingsContext: {
+		getInstance: () => ({
+			isFFA: () => false,
+		}),
+	},
+}));
+
+vi.mock('src/app/managers/ally-color-filter-manager', () => ({
+	AllyColorFilterManager: {
+		getInstance: () => ({
+			applyColorFilter: vi.fn(),
+		}),
+	},
+}));
+
+import { MinimapIconManager } from 'src/app/managers/minimap-icon-manager';
+import { AllyColorState } from 'src/app/managers/alliances/ally-color-state';
+import { PlayerManager } from 'src/app/player/player-manager';
+import { SharedSlotManager } from 'src/app/game/services/shared-slot-manager';
+
+describe('MinimapIconManager unit icon colors', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(AllyColorState as any).instance = new AllyColorState({
+			loadMode: () => 2,
+			saveMode: vi.fn(),
+		});
+
+		const localPlayer = Player(0);
+		(globalThis as any).GetLocalPlayer = () => localPlayer;
+		(globalThis as any).GetAllyColorFilterState = () => 0;
+		(globalThis as any).BlzFrameSetTexture = (frame: any, texture: string) => {
+			frame.texture = texture;
+		};
+
+		vi.mocked(PlayerManager.getInstance).mockReturnValue({
+			players: new Map([
+				[
+					localPlayer,
+					{
+						options: { colorblind: false, colorContrast: false },
+						status: { isDead: () => false },
+					},
+				],
+			]),
+		} as any);
+
+		vi.mocked(SharedSlotManager.getInstance).mockReturnValue({
+			getOwnerOfUnit: (unit: any) => unit.owner,
+		} as any);
+	});
+
+	it('uses custom ally mode 2 for initial local unit icon color', () => {
+		const localPlayer = Player(0);
+		const unit = { owner: localPlayer };
+		const frame = {};
+		const manager = Object.create(MinimapIconManager.prototype);
+
+		(manager as any).COLOR_TEXTURES = [];
+		(manager as any).COLOR_TEXTURES[1] = 'blue-texture';
+		(manager as any).COLOR_TEXTURES[99] = 'white-texture';
+		(manager as any).unitLastTexture = new Map();
+
+		(manager as any).updateUnitIconColor(frame, unit, localPlayer);
+
+		expect((frame as any).texture).toBe('blue-texture');
+	});
+});

--- a/tests/game-simulation/minimap-icon-manager-color.test.ts
+++ b/tests/game-simulation/minimap-icon-manager-color.test.ts
@@ -50,6 +50,8 @@ import { MinimapIconManager } from 'src/app/managers/minimap-icon-manager';
 import { AllyColorState } from 'src/app/managers/alliances/ally-color-state';
 import { PlayerManager } from 'src/app/player/player-manager';
 import { SharedSlotManager } from 'src/app/game/services/shared-slot-manager';
+import { MinimapTrackedList } from 'src/app/utils/minimap-tracked-list-logic';
+import { UNIT_TYPE } from 'src/app/utils/unit-types';
 
 describe('MinimapIconManager unit icon colors', () => {
 	beforeEach(() => {
@@ -65,6 +67,7 @@ describe('MinimapIconManager unit icon colors', () => {
 		(globalThis as any).BlzFrameSetTexture = (frame: any, texture: string) => {
 			frame.texture = texture;
 		};
+		(globalThis as any).FRAMEPOINT_CENTER = 'center';
 
 		vi.mocked(PlayerManager.getInstance).mockReturnValue({
 			players: new Map([
@@ -97,5 +100,55 @@ describe('MinimapIconManager unit icon colors', () => {
 		(manager as any).updateUnitIconColor(frame, unit, localPlayer);
 
 		expect((frame as any).texture).toBe('blue-texture');
+	});
+
+	it('refreshes a visible unloaded shared-slot minimap icon even when its texture cache is stale', () => {
+		const observer = Player(23);
+		const realOwner = Object.assign(Player(1), { color: 5 });
+		const sharedSlot = Object.assign(Player(12), { color: 2 });
+		const unit = { owner: sharedSlot, x: 50, y: 50 };
+		const frame = { texture: 'teal-texture', visible: false };
+		const manager = Object.create(MinimapIconManager.prototype);
+
+		(globalThis as any).GetLocalPlayer = () => observer;
+		(globalThis as any).IsPlayerObserver = (player: any) => player === observer;
+		(globalThis as any).IsUnitVisible = () => true;
+		(globalThis as any).UnitAlive = () => true;
+		(globalThis as any).IsUnitType = (_unit: any, unitType: any) => unitType === UNIT_TYPE.SPAWN;
+		(globalThis as any).GetOwningPlayer = (u: any) => u.owner;
+		(globalThis as any).GetUnitX = (u: any) => u.x;
+		(globalThis as any).GetUnitY = (u: any) => u.y;
+		(globalThis as any).BlzFrameSetAbsPoint = () => {};
+		(globalThis as any).BlzFrameSetVisible = (targetFrame: any, isVisible: boolean) => {
+			targetFrame.visible = isVisible;
+		};
+
+		vi.mocked(PlayerManager.getInstance).mockReturnValue({
+			players: new Map(),
+		} as any);
+		vi.mocked(SharedSlotManager.getInstance).mockReturnValue({
+			getOwnerOfUnit: (u: any) => (u.owner === sharedSlot ? realOwner : u.owner),
+		} as any);
+
+		(manager as any).isActive = true;
+		(manager as any).cityIcons = new Map();
+		(manager as any).trackedList = new MinimapTrackedList();
+		(manager as any).trackedList.addTrackedUnit(unit, frame, sharedSlot);
+		(manager as any).COLOR_TEXTURES = [];
+		(manager as any).COLOR_TEXTURES[5] = 'orange-owner-texture';
+		(manager as any).unitLastTexture = new Map([[unit, 'orange-owner-texture']]);
+		(manager as any).hudScale = 1;
+		(manager as any).MINIMAP_WIDTH = 0.14;
+		(manager as any).MINIMAP_HEIGHT = 0.14;
+		(manager as any).worldMinX = 0;
+		(manager as any).worldMinY = 0;
+		(manager as any).worldWidth = 100;
+		(manager as any).worldHeight = 100;
+
+		(manager as any).registerIfValid(unit, true);
+
+		expect(frame.texture).toBe('orange-owner-texture');
+		expect(frame.visible).toBe(true);
+		expect((manager as any).trackedList.trackedRawOwnerList[0]).toBe(sharedSlot);
 	});
 });

--- a/tests/game-simulation/transport-manager-color.test.ts
+++ b/tests/game-simulation/transport-manager-color.test.ts
@@ -18,6 +18,7 @@ import { UnitLagManager } from '../../src/app/game/services/unit-lag-manager';
 
 describe('TransportManager - Unload Color Application', () => {
 	let mockApplyColorFilter: MockInstance;
+	let mockRegisterIfValid: MockInstance;
 
 	beforeEach(() => {
 		// Reset singletons for testing
@@ -25,7 +26,8 @@ describe('TransportManager - Unload Color Application', () => {
 		(TransportManager as any).delayedTrackQueue = [];
 
 		// Mock MinimapIconManager
-		const minIconObj = { registerIfValid: vi.fn(), unregisterTrackedUnit: vi.fn() };
+		mockRegisterIfValid = vi.fn();
+		const minIconObj = { registerIfValid: mockRegisterIfValid, unregisterTrackedUnit: vi.fn() };
 		vi.spyOn(MinimapIconManager, 'getInstance').mockReturnValue(minIconObj as any);
 
 		// Mock UnitLagManager
@@ -86,6 +88,8 @@ describe('TransportManager - Unload Color Application', () => {
 		// Then applyColorFilter should be called
 		expect(mockApplyColorFilter).toHaveBeenCalledWith(fakeUnit);
 		expect(mockApplyColorFilter).toHaveBeenCalledTimes(1);
+		expect(mockRegisterIfValid).toHaveBeenCalledWith(fakeUnit, true);
+		expect(mockRegisterIfValid).toHaveBeenCalledTimes(1);
 	});
 
 	it('should call applyColorFilter for units when a transport dies', () => {
@@ -106,5 +110,8 @@ describe('TransportManager - Unload Color Application', () => {
 		expect(mockApplyColorFilter).toHaveBeenCalledWith(fakeCargoUnit1);
 		expect(mockApplyColorFilter).toHaveBeenCalledWith(fakeCargoUnit2);
 		expect(mockApplyColorFilter).toHaveBeenCalledTimes(2);
+		expect(mockRegisterIfValid).toHaveBeenCalledWith(fakeCargoUnit1, true);
+		expect(mockRegisterIfValid).toHaveBeenCalledWith(fakeCargoUnit2, true);
+		expect(mockRegisterIfValid).toHaveBeenCalledTimes(2);
 	});
 });

--- a/tests/game-simulation/transport-tracking-lifecycle.test.ts
+++ b/tests/game-simulation/transport-tracking-lifecycle.test.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import './helpers/wc3-integration-shim';
+
+const mocks = vi.hoisted(() => ({
+	onUnitTrain: vi.fn(),
+	trackUnit: vi.fn(),
+	applyColorFilter: vi.fn(),
+	playerManager: {
+		players: new Map<any, any>(),
+	},
+	sharedSlotManager: {
+		getOwnerOfUnit: vi.fn(),
+		getSlotWithLowestUnitCount: vi.fn(),
+		incrementUnitCount: vi.fn(),
+	},
+}));
+
+vi.mock('w3ts', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('w3ts/system/file', () => ({
+	File: { read: vi.fn(() => ''), write: vi.fn() },
+}));
+
+vi.mock('../../src/app/city/city-map', () => ({
+	UnitToCity: {
+		get: () => ({
+			onUnitTrain: mocks.onUnitTrain,
+		}),
+	},
+}));
+
+vi.mock('../../src/app/game/services/unit-lag-manager', () => ({
+	UnitLagManager: {
+		getInstance: () => ({
+			trackUnit: mocks.trackUnit,
+		}),
+	},
+}));
+
+vi.mock('../../src/app/managers/ally-color-filter-manager', () => ({
+	AllyColorFilterManager: {
+		getInstance: () => ({
+			applyColorFilter: mocks.applyColorFilter,
+		}),
+	},
+}));
+
+vi.mock('../../src/app/player/player-manager', () => ({
+	PlayerManager: {
+		getInstance: () => mocks.playerManager,
+	},
+}));
+
+vi.mock('../../src/app/game/services/shared-slot-manager', () => ({
+	SharedSlotManager: {
+		getInstance: () => mocks.sharedSlotManager,
+	},
+}));
+
+import { GlobalGameData } from '../../src/app/game/state/global-game-state';
+import { HumanPlayer } from '../../src/app/player/types/human-player';
+import { UnitTrainedEvent } from '../../src/app/triggers/unit-trained-event';
+import { UNIT_TYPE } from '../../src/app/utils/unit-types';
+
+describe('Transport tracked data lifecycle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.playerManager.players = new Map<any, any>();
+		mocks.sharedSlotManager.getOwnerOfUnit.mockReset();
+		mocks.sharedSlotManager.getSlotWithLowestUnitCount.mockReset();
+		mocks.sharedSlotManager.incrementUnitCount.mockReset();
+
+		GlobalGameData.resetInstance();
+		GlobalGameData.prepareMatchData([]);
+		GlobalGameData.matchState = 'inProgress';
+
+		(globalThis as any).TriggerAddCondition = (_trigger: any, condition: () => boolean) => {
+			condition();
+		};
+		(globalThis as any).GetTriggerUnit = () => ({ id: 'port-city' });
+		(globalThis as any).GetOwningPlayer = (unit: any) => unit.owner;
+		(globalThis as any).SetUnitOwner = (unit: any, owner: any) => {
+			unit.owner = owner;
+		};
+		(globalThis as any).IsUnitType = (unit: any, unitType: any) => unit.typeIds?.includes(unitType) ?? false;
+		(globalThis as any).ORIGIN_FRAME_GAME_UI = {};
+		(globalThis as any).BlzFrameSetValue = () => {};
+	});
+
+	it('adds trained transports to the real owner transport set without counting them as survival units', () => {
+		const realOwner = Player(0);
+		const sharedTrainingSlot = Player(12);
+		const trainedTransport = { id: 'transport', owner: sharedTrainingSlot, typeIds: [UNIT_TYPE.TRANSPORT] };
+		const trackedData = { units: new Set<any>(), transports: new Set<any>() };
+
+		mocks.sharedSlotManager.getOwnerOfUnit.mockReturnValue(realOwner);
+		mocks.playerManager.players.set(realOwner, { trackedData });
+		(globalThis as any).GetTrainedUnit = () => trainedTransport;
+
+		UnitTrainedEvent();
+
+		expect(trackedData.transports.has(trainedTransport)).toBe(true);
+		expect(trackedData.units.has(trainedTransport)).toBe(false);
+		expect(trainedTransport.owner).toBe(realOwner);
+	});
+
+	it('removes dead transports from the owner transport set without touching survival units', () => {
+		const owner = Player(0);
+		const deadTransport = { id: 'dead-transport', owner, typeIds: [UNIT_TYPE.TRANSPORT] };
+		const survivingUnit = { id: 'surviving-unit', owner };
+		const activePlayer = new HumanPlayer(owner);
+
+		activePlayer.trackedData.transports.add(deadTransport as any);
+		activePlayer.trackedData.units.add(survivingUnit as any);
+
+		activePlayer.onDeath(owner, deadTransport as any, false);
+
+		expect(activePlayer.trackedData.transports.has(deadTransport as any)).toBe(false);
+		expect(activePlayer.trackedData.units.has(survivingUnit as any)).toBe(true);
+	});
+});


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the ally color filter system, minimap icon management, and data tracking for units and transports. The main focus is on ensuring that transports are tracked and colored correctly, that neutral player colors are preserved in all color modes, and that minimap icons refresh properly after unit state changes. It also expands test coverage for these behaviors.

**Ally color system and neutral player handling:**
- Added logic in `AllyColorState` to detect neutral players and ensure their colors remain unchanged in all ally color modes, with corresponding tests to verify this behavior. [[1]](diffhunk://#diff-5101797247c0ec9ca35a0610d6602f3a00cda4e89c0453a1bf2f7f7e520977e3R43-R46) [[2]](diffhunk://#diff-5101797247c0ec9ca35a0610d6602f3a00cda4e89c0453a1bf2f7f7e520977e3R68-R70) [[3]](diffhunk://#diff-032bd79fb15bb2d2fbccf848ad9f8ac1726a6a992269ef4977d4d08c4c803aaeR13-R16) [[4]](diffhunk://#diff-032bd79fb15bb2d2fbccf848ad9f8ac1726a6a992269ef4977d4d08c4c803aaeR83) [[5]](diffhunk://#diff-032bd79fb15bb2d2fbccf848ad9f8ac1726a6a992269ef4977d4d08c4c803aaeR128-R140) [[6]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R130-R159)

**Transport tracking and color application:**
- Transports are now tracked separately from other units in `TrackedData`, are properly added/removed on training and death, and have their color filters reapplied when ally color mode changes. [[1]](diffhunk://#diff-4e2843b831bdbd4c34415873ab2993ac781ecb3b6629ba077b29dc3e422322adR26) [[2]](diffhunk://#diff-4e2843b831bdbd4c34415873ab2993ac781ecb3b6629ba077b29dc3e422322adR56) [[3]](diffhunk://#diff-4e2843b831bdbd4c34415873ab2993ac781ecb3b6629ba077b29dc3e422322adR81) [[4]](diffhunk://#diff-4e2843b831bdbd4c34415873ab2993ac781ecb3b6629ba077b29dc3e422322adR156-R160) [[5]](diffhunk://#diff-b8fe08e67ca046011fac66f2f31a5900a113af2ab6dcf3284843de95cf9f658cL70-R72) [[6]](diffhunk://#diff-2614e35c70508fee9a75992d36cc0865ead97cc9ccd90731f97ec7fc4182e47fR44) [[7]](diffhunk://#diff-68a4cc1127781ed4580aa56cebfaeebe1f7d2bcda1398ef4187b997c0a52d76eR72-R74) [[8]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R75) [[9]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R223-R241)

**Minimap icon management improvements:**
- Minimap icon registration now allows forced refreshes, and a new method ensures that icons are updated after lifecycle events (like transport unloading) to avoid stale textures. [[1]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355L214-L226) [[2]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355R231-R234) [[3]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355R343-R373) [[4]](diffhunk://#diff-8a92ae4165bee2410565ca57877c472a485bb230037f9bbb1c0a60c62ad934a4L223-R223) [[5]](diffhunk://#diff-8a92ae4165bee2410565ca57877c472a485bb230037f9bbb1c0a60c62ad934a4L262-R262)

**Ally color filter and color mode fixes:**
- The color filter manager now reads the live player color when necessary instead of using a cached value, ensuring correct display after color randomization or changes. [[1]](diffhunk://#diff-68a4cc1127781ed4580aa56cebfaeebe1f7d2bcda1398ef4187b997c0a52d76eR203-R212) [[2]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R55) [[3]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R130-R159)

**Testing and code quality:**
- Expanded and improved tests for the ally color filter manager and color state, including mocks for global functions and tests for neutral player handling and transport color application. [[1]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R15) [[2]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R37) [[3]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R75) [[4]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R130-R159) [[5]](diffhunk://#diff-6fcb81bf68a54ee6bace5b93e0a5a2432a9492e8b36e14aaf288565b3b943e41R223-R241)

Additionally, the map version string was updated to `'dev'` for development builds.