### PR TITLE
fix: keep minimap icon white for local player in ally color mode 2

### DIFF
--- a/docs/shared-slots/unit-color-assignment-readme.md
+++ b/docs/shared-slots/unit-color-assignment-readme.md
@@ -32,7 +32,7 @@ In normal visual modes, it resolves the real owner and applies `GetPlayerColor(r
 
 | Relation to local player | Unit model color in mode 2                    | Minimap color in mode 1/2           |
 | ------------------------ | --------------------------------------------- | ----------------------------------- |
-| Self                     | Blue                                          | White in mode 0/1, Blue in mode 2   |
+| Self                     | Blue                                          | White                               |
 | Ally or teammate         | Teal, or Yellow for colorblind mode           | Teal, or Yellow for colorblind mode |
 | Enemy                    | Red                                           | Red                                 |
 | Neutral                  | Neutral/default; high contrast can tint black | Gray/neutral texture                |

--- a/src/app/managers/minimap-icon-manager.ts
+++ b/src/app/managers/minimap-icon-manager.ts
@@ -755,9 +755,9 @@ export class MinimapIconManager {
 		// Check ally color filter mode
 		// 0 = Player colors, 1/2 = Ally/Enemy colors
 
-		// If the local player owns this city, show it in WHITE (or BLUE in Ally Mode 2)
+		// If the local player owns this city, show it in WHITE
 		if (owner === effectiveLocal) {
-			const localTexture = allyColorMode === 2 ? this.COLOR_TEXTURES[1] : this.COLOR_TEXTURES[99];
+			const localTexture = this.COLOR_TEXTURES[99];
 			this.setTextureCached(city, iconFrame, localTexture, this.cityLastTexture);
 			return;
 		}
@@ -820,9 +820,9 @@ export class MinimapIconManager {
 		// Used the SharedSlotManager to resolve the real owner (maps SharedSlot -> Player)
 		const owner = sharedSlotManager.getOwnerOfUnit(unit);
 
-		// If the local player owns this unit (or owns the shared slot), show it in WHITE (or BLUE in Ally Mode 2)
+		// If the local player owns this unit (or owns the shared slot), show it in WHITE
 		if (owner === effectiveLocal) {
-			const localTexture = allyColorMode === 2 ? this.COLOR_TEXTURES[1] : this.COLOR_TEXTURES[99];
+			const localTexture = this.COLOR_TEXTURES[99];
 			this.setTextureCached(iconFrame, iconFrame, localTexture, this.frameLastTexture);
 			return;
 		}
@@ -916,9 +916,9 @@ export class MinimapIconManager {
 		// Check ally color filter mode
 		// 0 = Player colors, 1/2 = Ally/Enemy colors
 
-		// If the local player owns this city, show it in WHITE (or BLUE in Ally Mode 2)
+		// If the local player owns this city, show it in WHITE
 		if (owner === localPlayer) {
-			const localTexture = allyColorMode === 2 ? this.COLOR_TEXTURES[1] : this.COLOR_TEXTURES[99];
+			const localTexture = this.COLOR_TEXTURES[99];
 			this.setTextureCached(city, iconFrame, localTexture, this.cityLastTexture);
 			return;
 		}
@@ -981,9 +981,9 @@ export class MinimapIconManager {
 			allyColorMode = 2;
 		}
 
-		// If the local player owns this unit (or owns the shared slot), show it in WHITE (or BLUE in Ally Mode 2)
+		// If the local player owns this unit (or owns the shared slot), show it in WHITE
 		if (owner === localPlayer) {
-			const localTexture = allyColorMode === 2 ? this.COLOR_TEXTURES[1] : this.COLOR_TEXTURES[99];
+			const localTexture = this.COLOR_TEXTURES[99];
 			this.setTextureCached(iconFrame, iconFrame, localTexture, this.frameLastTexture);
 			return;
 		}

--- a/tests/game-simulation/minimap-icon-manager-color.test.ts
+++ b/tests/game-simulation/minimap-icon-manager-color.test.ts
@@ -100,7 +100,7 @@ describe('MinimapIconManager unit icon colors', () => {
 
 		(manager as any).updateUnitIconColor(frame, unit, localPlayer);
 
-		expect((frame as any).texture).toBe('blue-texture');
+		expect((frame as any).texture).toBe('white-texture');
 	});
 
 	it('updates previously assigned frame color when frame is recycled for a new unit', () => {


### PR DESCRIPTION
This pull request standardizes the minimap color for the local player's units and cities to always appear as white, regardless of the ally color mode. Previously, in certain modes, these could appear blue. The changes affect both the implementation and documentation, as well as the related unit test.

Minimap color assignment changes:

* Updated the minimap icon color logic in `MinimapIconManager` so that units and cities owned by the local player are always shown in white, removing the previous behavior where they could appear blue in ally color mode 2. [[1]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355L758-R760) [[2]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355L823-R825) [[3]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355L919-R921) [[4]](diffhunk://#diff-56f3fa736c4021fa9daf171f32f3826a1462f31e612a0f67317d3160de738355L984-R986)
* Updated the documentation in `unit-color-assignment-readme.md` to reflect that the local player's minimap color is always white, not blue in any mode.

Testing:

* Updated the unit test in `minimap-icon-manager-color.test.ts` to expect the local player's icon texture to be white instead of blue.