### PR TITLE
Feature/observer camera resized

### DIFF
--- a/src/app/managers/player-camera-position-manager.ts
+++ b/src/app/managers/player-camera-position-manager.ts
@@ -24,6 +24,7 @@ export default class PlayerCameraPositionManager {
 	private syncTrigger: trigger;
 	private overlayVisible: boolean = false;
 	private toggleButton: framehandle;
+	private toggleIcon: framehandle;
 
 	public static getInstance() {
 		if (this.instance === undefined) {
@@ -104,8 +105,10 @@ export default class PlayerCameraPositionManager {
 		const localPlayer = GetLocalPlayer();
 
 		BlzFrameSetVisible(this.toggleButton, false);
+		BlzFrameSetVisible(this.toggleIcon, false);
 		if (IsPlayerObserver(localPlayer) || EDITOR_DEVELOPER_MODE) {
 			BlzFrameSetVisible(this.toggleButton, true);
+			BlzFrameSetVisible(this.toggleIcon, true);
 		} else {
 			BlzFrameSetEnable(this.toggleButton, false);
 		}
@@ -115,18 +118,26 @@ export default class PlayerCameraPositionManager {
 		const gameUI = BlzGetOriginFrame(ORIGIN_FRAME_GAME_UI, 0);
 		const ctx = 500; // unique context to avoid collision with player frames
 
+		this.toggleIcon = BlzCreateFrameByType('BACKDROP', 'CamToggleIcon', gameUI, '', ctx);
+		BlzFrameSetPoint(this.toggleIcon, FRAMEPOINT_TOPLEFT, gameUI, FRAMEPOINT_TOPLEFT, 0.138, -0.025);
+		BlzFrameSetSize(this.toggleIcon, 0.02, 0.02);
+		BlzFrameSetTexture(this.toggleIcon, 'ReplaceableTextures\\CommandButtonsDisabled\\DISBTNTelescope.blp', 0, true);
+
 		// Use ScriptDialogButton — same template as the leaderboard button, proven to work with observer hover detection
 		this.toggleButton = BlzCreateFrameByType('GLUETEXTBUTTON', 'CamToggleButton', gameUI, 'ScriptDialogButton', ctx);
 		BlzFrameSetPoint(this.toggleButton, FRAMEPOINT_TOPLEFT, gameUI, FRAMEPOINT_TOPLEFT, 0.138, -0.025);
 		BlzFrameSetSize(this.toggleButton, 0.02, 0.02);
-		BlzFrameSetText(this.toggleButton, 'Cameras: Off');
+		BlzFrameSetText(this.toggleButton, '');
+		BlzFrameSetAlpha(this.toggleButton, 0);
 
 		const localPlayer = GetLocalPlayer();
 
 		// Only visible for observers or developers
 		BlzFrameSetVisible(this.toggleButton, false);
+		BlzFrameSetVisible(this.toggleIcon, false);
 		if (IsPlayerObserver(localPlayer) || EDITOR_DEVELOPER_MODE) {
 			BlzFrameSetVisible(this.toggleButton, true);
+			BlzFrameSetVisible(this.toggleIcon, true);
 		} else {
 			BlzFrameSetEnable(this.toggleButton, false);
 		}
@@ -139,7 +150,12 @@ export default class PlayerCameraPositionManager {
 
 	private toggleOverlay(): void {
 		this.overlayVisible = !this.overlayVisible;
-		BlzFrameSetText(this.toggleButton, this.overlayVisible ? 'Cameras: On' : 'Cameras: Off');
+		BlzFrameSetText(this.toggleButton, '');
+
+		const texture = this.overlayVisible
+			? 'ReplaceableTextures\\CommandButtons\\BTNTelescope.blp'
+			: 'ReplaceableTextures\\CommandButtonsDisabled\\DISBTNTelescope.blp';
+		BlzFrameSetTexture(this.toggleIcon, texture, 0, true);
 
 		if (!this.overlayVisible) {
 			this.frames.forEach((frame) => {

--- a/src/app/managers/player-camera-position-manager.ts
+++ b/src/app/managers/player-camera-position-manager.ts
@@ -117,8 +117,8 @@ export default class PlayerCameraPositionManager {
 
 		// Use ScriptDialogButton — same template as the leaderboard button, proven to work with observer hover detection
 		this.toggleButton = BlzCreateFrameByType('GLUETEXTBUTTON', 'CamToggleButton', gameUI, 'ScriptDialogButton', ctx);
-		BlzFrameSetPoint(this.toggleButton, FRAMEPOINT_TOPLEFT, gameUI, FRAMEPOINT_TOPLEFT, 0.092, -0.025);
-		BlzFrameSetSize(this.toggleButton, 0.1, 0.03);
+		BlzFrameSetPoint(this.toggleButton, FRAMEPOINT_TOPLEFT, gameUI, FRAMEPOINT_TOPLEFT, 0.138, -0.025);
+		BlzFrameSetSize(this.toggleButton, 0.02, 0.02);
 		BlzFrameSetText(this.toggleButton, 'Cameras: Off');
 
 		const localPlayer = GetLocalPlayer();


### PR DESCRIPTION
This pull request updates the camera toggle UI in the `PlayerCameraPositionManager` to use an icon instead of a text label, improving the visual appearance and clarity of the toggle functionality. The changes introduce a new `toggleIcon` frame, update its texture based on the overlay state, and adjust the button and icon visibility logic.

UI improvements for camera toggle:

* Added a new `toggleIcon` (`framehandle`) to the class, created as a `BACKDROP` frame, positioned and sized to match the toggle button, and initialized with a disabled telescope texture. (`[[1]](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcR27)`, `[[2]](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcR121-R140)`)
* Updated the toggle button to remove text, set its alpha to 0 (making it invisible), and match the icon's position and size, effectively making the icon the visible toggle element. (`[src/app/managers/player-camera-position-manager.tsR121-R140](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcR121-R140)`)
* Changed the visibility logic so that both the button and the icon are only shown to observers or developers, and are hidden otherwise. (`[[1]](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcR108-R111)`, `[[2]](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcR121-R140)`)
* Modified the `toggleOverlay` method to update the icon's texture depending on whether the overlay is visible (active/inactive telescope icon), and removed the button text update. (`[src/app/managers/player-camera-position-manager.tsL142-R158](diffhunk://#diff-7f040f33d1ce61fb79fdaf6b4d34268bb1c1be99b01b0aeca0fae6ea395fc6dcL142-R158)`)